### PR TITLE
Publishing API now expects a 'publishing-app' field

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -19,6 +19,7 @@ private
     publishing_api.put_content_item(from_path, {
       "base_path" => from_path,
       "format" => "redirect",
+      "publishing_app" => "short-url-manager",
       "update_type" => "major",
       "redirects" => [
         { "path" => from_path, "type" => "exact", "destination" => to_path }


### PR DESCRIPTION
This expectation was added after short-url-manager was built, but
the change was causing redirect registration to fail since the
API change

(https://www.agileplannerapp.com/boards/105200/cards/6075)

I wanted to catch the specific exception and log it, to something like errbit (so that debugging API errors can be done more easily next time), but I wasn't sure how with Errbit.

```
rescue GdsApi::HTTPErrorResponse => exception
  log(exception)
  errors.add(:base, "An error posting to the publishing API prevented this redirect from being created.")
  false # Do not continue to save
end
```
