### PR TITLE
Give default auth user all permissions, for manual testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ $ ./startup.sh
 
 If you are using the GDS development virtual machine then the application will be available on the host at [http://short-url-manager.dev.gov.uk/](http://short-url-manager.dev.gov.uk/)
 
-### Authentication in dev
-
-In dev `gds-sso` will authenticate you as the first user in the User collection. You will need to give this user any missing permissions you need
-
 ## Running the test suite
 
 ```

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -6,3 +6,17 @@ GDS::SSO.config do |config|
   config.oauth_secret = ENV['OAUTH_SECRET']
   config.oauth_root_url = Plek.current.find('signon')
 end
+
+
+# In development, if we want to be able to test API requests to the tags
+# endpoints, we need to override the permissions for the dummy user inserted by
+# GDS::SSO in the mock_bearer_token strategy.
+#
+# The easiest way to do this is just to override the GDS::SSO test user with a
+# new user we create here.
+#
+GDS::SSO.test_user = User.find_or_create_by(email: 'user@test.example').tap do |u|
+  u.name = 'Test User'
+  u.permissions = ['signin', 'manage_short_urls', 'request_short_urls']
+  u.save!
+end


### PR DESCRIPTION
Previously you'd need to modify your local DB to give the first
user the right permissions. This will automatically set up a
custom user with all the required permissions as the default
auth user, that you'll be when running the app locally.

The README auth section can be removed, as it should "Just Work"

Inspired by https://github.com/alphagov/panopticon/pull/219
