### PR TITLE
Replace blog link with "one guidance" project guide

### DIFF
--- a/app/views/short_url_requests/new.html.erb
+++ b/app/views/short_url_requests/new.html.erb
@@ -1,6 +1,6 @@
 <h1 class="page-title-with-border">Request a short URL</h1>
 
-<p>If you are not familiar with requesting short URLs, please read <a href="https://insidegovuk.blog.gov.uk/2014/04/07/how-to-request-a-short-url/">this blog post</a> first.</p>
+<p>If you are not familiar with requesting short URLs, please read <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">this guidance</a> first.</p>
 
 <%= form_for @short_url_request, url: { action: :create } do |f| %>
   <%= render_errors_for @short_url_request, leading_message: "Your request for a short URL could not be made for the following reasons:" %>


### PR DESCRIPTION
The blog post is deprecated, the GOV.UK guidance is the new source of truth.
