### PR TITLE
Strip trailing spaces on the redirect paths before they hit the API

### DIFF
--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -20,6 +20,7 @@ class ShortUrlRequest
   validates :state, inclusion: { in: %w(pending accepted rejected) }, allow_blank: true
 
   before_validation :retreive_organisation_title, unless: ->{ organisation_title.present? }
+  before_validation :strip_whitespace, :only => [:from_path, :to_path]
 
   scope :pending, -> { where(state: "pending") }
 
@@ -56,5 +57,10 @@ class ShortUrlRequest
 private
   def retreive_organisation_title
     self.organisation_title = Organisation.where(slug: organisation_slug).first.try(:title)
+  end
+
+  def strip_whitespace
+    self.from_path = self.from_path.strip
+    self.to_path = self.to_path.strip
   end
 end

--- a/spec/factories/redirect_factories.rb
+++ b/spec/factories/redirect_factories.rb
@@ -7,4 +7,9 @@ FactoryGirl.define do
       to_path nil
     }
   end
+
+  factory :redirect_with_whitespace, class: 'Redirect' do
+    sequence(:from_path) { |n| "/short-url-from-#{n} " }
+    sequence(:to_path) { |n| "/short-url-to-#{n} " }
+  end
 end

--- a/spec/models/furl_request_spec.rb
+++ b/spec/models/furl_request_spec.rb
@@ -27,6 +27,13 @@ describe ShortUrlRequest do
       expect(build :short_url_request, state: 'rejected').to be_valid
       expect(build :short_url_request, state: 'liquid').to_not be_valid
     end
+
+    it "should trim whitespace from from_path and to_path" do
+      from_path_stripped_whitespace = create(:short_url_request, from_path: '/a-path ')
+      to_path_stripped_whitespace = create(:short_url_request, to_path: '/b-path ')
+      expect(from_path_stripped_whitespace.from_path).to eq('/a-path')
+      expect(to_path_stripped_whitespace.to_path).to eq('/b-path')
+    end
   end
 
   describe "scopes" do


### PR DESCRIPTION
- "An error posting to the Publishing API" was being raised with no
  further context for users that it could have been (and in the case
  reported in Slack, was indeed) a whitespace issue.
