### PR TITLE
Upgrade Bootstrap to 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'will_paginate_mongoid', '~> 2.0.1'
 gem 'redis', '3.0.7', require: false # Used by the Organisation importer as a locking mechanism
 gem 'mlanett-redis-lock', '0.2.2' # Used by the Organisation importer as a locking mechanism
 
-gem 'govuk_admin_template', '1.1.6'
+gem 'govuk_admin_template', '1.4.0'
 gem 'gds-sso', '~> 9.3.0'
 gem 'plek', '~> 1.8.1'
 gem 'gds-api-adapters', '~> 14.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       builder
       multi_json
     arel (5.0.1.20140414130214)
-    bootstrap-sass (3.2.0.2)
+    bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
     bson (2.3.0)
     builder (3.2.2)
@@ -80,8 +80,8 @@ GEM
       rails (>= 3.0.0)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
-    govuk_admin_template (1.1.6)
-      bootstrap-sass (~> 3.2.0.2)
+    govuk_admin_template (1.4.0)
+      bootstrap-sass (~> 3.3.1)
       jquery-rails (~> 3.1.1)
       rails (>= 3.2.0)
     hashie (3.2.0)
@@ -257,7 +257,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.4.1)
   gds-api-adapters (~> 14.1.0)
   gds-sso (~> 9.3.0)
-  govuk_admin_template (= 1.1.6)
+  govuk_admin_template (= 1.4.0)
   logstasher (~> 0.5.3)
   mlanett-redis-lock (= 0.2.2)
   mongoid (~> 4.0.0)


### PR DESCRIPTION
Bump admin gem to pick up Bootstrap 3.3 (see https://github.com/alphagov/govuk_admin_template/pull/53)
For testing, everything on this branch should look and behave as it did before.

https://www.agileplannerapp.com/boards/173808/cards/8764
