### PR TITLE
Fix typo originating in a test helper: authourised => authorised

### DIFF
--- a/spec/controllers/short_url_requests_controller_spec.rb
+++ b/spec/controllers/short_url_requests_controller_spec.rb
@@ -10,8 +10,8 @@ describe ShortUrlRequestsController do
       let(:user) { create(:user, permissions: ['signon', 'manage_short_urls']) }
 
       specify {
-        expect_not_authourised(:get, :new)
-        expect_not_authourised(:post, :create)
+        expect_not_authorised(:get, :new)
+        expect_not_authorised(:post, :create)
       }
     end
 
@@ -19,11 +19,11 @@ describe ShortUrlRequestsController do
       let(:user) { create(:user, permissions: ['signon', 'request_short_urls']) }
 
       specify {
-        expect_not_authourised(:get, :index)
-        expect_not_authourised(:get, :show, id: 'required-param')
-        expect_not_authourised(:post, :accept, id: 'required-param')
-        expect_not_authourised(:get, :new_rejection, id: 'required-param')
-        expect_not_authourised(:post, :reject, id: 'required-param')
+        expect_not_authorised(:get, :index)
+        expect_not_authorised(:get, :show, id: 'required-param')
+        expect_not_authorised(:post, :accept, id: 'required-param')
+        expect_not_authorised(:get, :new_rejection, id: 'required-param')
+        expect_not_authorised(:post, :reject, id: 'required-param')
       }
     end
   end

--- a/spec/support/sso_helper.rb
+++ b/spec/support/sso_helper.rb
@@ -32,12 +32,7 @@ module SSOControllerHelper
     )
   end
 
-  def expect_authourised(http_method, action, params={})
-    send(http_method, action, params)
-    expect(response.status).to_not eql 403
-  end
-
-  def expect_not_authourised(http_method, action, params={})
+  def expect_not_authorised(http_method, action, params={})
     send(http_method, action, params)
     expect(response.status).to eql 403
   end


### PR DESCRIPTION
- Doing a global find and replace across the app, it seems like
  `expect_authourised` [sic] isn't used anywhere, so I've removed it.