### PR TITLE
Add a list page showing all approved short URL requests in this app's database

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -1,6 +1,6 @@
 class ShortUrlRequestsController < ApplicationController
   before_filter :authorise_as_short_url_requester!, only: [:new, :create]
-  before_filter :authorise_as_short_url_manager!, only: [:index, :show, :accept, :new_rejection, :reject]
+  before_filter :authorise_as_short_url_manager!, only: [:index, :show, :accept, :new_rejection, :reject, :list_short_urls]
   before_filter :get_short_url_request, only: [:show, :accept, :new_rejection, :reject]
 
   def index
@@ -8,6 +8,10 @@ class ShortUrlRequestsController < ApplicationController
   end
 
   def show
+  end
+
+  def list_short_urls
+    @accepted_short_urls = ShortUrlRequest.all.where(state: 'accepted').order_by([:created_at, 'desc']).paginate(page: (params[:page]), per_page: 40)
   end
 
   def new

--- a/app/views/dashboard/dashboard.html.erb
+++ b/app/views/dashboard/dashboard.html.erb
@@ -6,5 +6,6 @@
   <% end %>
   <% if current_user.can_manage_short_urls? %>
     <li class="list-group-item"><%= link_to "Manage short URL requests", short_url_requests_path %></li>
+    <li class="list-group-item"><%= link_to "View all accepted short URLs managed by this app", list_short_urls_path %></li>
   <% end %>
 </ul>

--- a/app/views/short_url_requests/_short_url_request_data.html.erb
+++ b/app/views/short_url_requests/_short_url_request_data.html.erb
@@ -16,4 +16,7 @@
 
   <dt>Contact email:</dt>
   <dd><%= short_url_request.contact_email %></dd>
+
+  <dt>State:</dt>
+  <dd><%= short_url_request.state.titleize %></dd>
 </dl>

--- a/app/views/short_url_requests/list_short_urls.html.erb
+++ b/app/views/short_url_requests/list_short_urls.html.erb
@@ -1,0 +1,20 @@
+<table class="table table-bordered table-hover">
+  <thead>
+    <tr class="table-header">
+      <th>Organisation</th>
+      <th>From</th>
+      <th>To</th>
+      <th>State</th>
+      <th>Date</th>
+    </tr>
+  </thead>
+  <% @accepted_short_urls.each do |request| %>
+    <tr class="clickable_row">
+      <td><%= link_to request.organisation_title, short_url_request_path(request) %></td>
+      <td><%= link_to request.from_path, short_url_request_path(request) %></td>
+      <td><%= link_to request.to_path, short_url_request_path(request) %></td>
+      <td><%= link_to request.state.titleize, short_url_request_path(request) %></td>
+      <td><%= link_to request.updated_at.to_date, short_url_request_path(request) %></td>
+    </tr>
+  <% end %>
+</table>

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -2,6 +2,8 @@
 
 <%= render 'short_url_request_data', short_url_request: @short_url_request %>
 
-<%= button_to "Accept and create redirect", accept_short_url_request_path(@short_url_request), method: :post, class: "btn btn-success" %>
-<%= link_to "Reject", new_rejection_short_url_request_path(@short_url_request), class: "btn btn-danger" %>
-<%= link_to "Back", short_url_requests_path, class: "btn btn-default" %>
+<% if @short_url_request.state == 'pending' %>
+  <%= button_to "Accept and create redirect", accept_short_url_request_path(@short_url_request), method: :post, class: "btn btn-success" %>
+  <%= link_to "Reject", new_rejection_short_url_request_path(@short_url_request), class: "btn btn-danger" %>
+  <%= link_to "Back", short_url_requests_path, class: "btn btn-default" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       post "reject" => "short_url_requests#reject"
     end
   end
+  get "list_short_urls" => "short_url_requests#list_short_urls"
 
   get "/healthcheck" => Proc.new { [200, {}, ["OK"]] }
 


### PR DESCRIPTION
- Based on https://www.agileplannerapp.com/boards/105200/cards/5112, this adds a page at `/list_all_redirects` that shows all of the accepted short URLs that this app knows about from its database and links out to their respective `show` pages.

![screen shot 2015-01-14 at 12 46 00](https://cloud.githubusercontent.com/assets/355033/5738991/55e8642c-9beb-11e4-8ca1-d725d3f56a47.png)

- Depending on where the user comes from, display either the confirm/reject/back buttons or nothing at all in the case of coming from `/list_all_redirects`. The list all page should not, IMO, be a place to deal with the requests - that should go through "manage requests".

![screen shot 2015-01-13 at 16 53 14](https://cloud.githubusercontent.com/assets/355033/5724618/bb963846-9b44-11e4-9b14-8cb2119e0eb8.png)

- Add a link to the new list page from the dashboard, only visible to managers.

![screen shot 2015-01-14 at 12 49 57](https://cloud.githubusercontent.com/assets/355033/5739033/e5ed3660-9beb-11e4-9c6b-e842a0ad7d6d.png)


:fire: