### PR TITLE
For each of the links on the list page, add a delete button

### DIFF
--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -16,7 +16,7 @@ class ShortUrlRequest
 
   validates :state, :from_path, :to_path, :reason, :contact_email, :organisation_slug, :organisation_title, presence: true
   validates :from_path, :to_path, format: { with: /\A\//, message: 'must be specified as a relative path (eg. "/hmrc/tax-returns")' }, allow_blank: true
-  validates :state, inclusion: { in: %w(pending accepted rejected) }, allow_blank: true
+  validates :state, inclusion: { in: %w(pending accepted rejected deleted) }, allow_blank: true
 
   before_validation :retreive_organisation_title, unless: ->{ organisation_title.present? }
   before_validation :strip_whitespace, :only => [:from_path, :to_path]

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -5,5 +5,7 @@
 <% if @short_url_request.state == 'pending' %>
   <%= button_to "Accept and create redirect", accept_short_url_request_path(@short_url_request), method: :post, class: "btn btn-success" %>
   <%= link_to "Reject", new_rejection_short_url_request_path(@short_url_request), class: "btn btn-danger" %>
+<% else %>
+  <%= button_to "Remove this redirect", short_url_request_path(@short_url_request), method: :delete, class: "btn btn-danger" %>
 <% end %>
 <%= link_to "Back", short_url_requests_path, class: "btn btn-default" %>


### PR DESCRIPTION
- Add the delete button to the show page in place of the accept or
  reject buttons, for all redirects except those in 'pending' state.
- Remove the redirect from the router. If this succeeds, remove it from
  this app's database.
- Make a `router` method so we use the same router object everytime,
  and it's easier to test. Test the `destroy` method in the
  ShortUrlRequestsControllerSpec, with some stubbing and mocking for the
  Router part - thanks to Russell Garner for the help.

:fire: