### PR TITLE
Upgrade the gds-api-adapters gem version to 17.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'mlanett-redis-lock', '0.2.2' # Used by the Organisation importer as a locki
 gem 'govuk_admin_template', '1.4.0'
 gem 'gds-sso', '~> 9.3.0'
 gem 'plek', '~> 1.8.1'
-gem 'gds-api-adapters', '~> 14.1.0'
+gem 'gds-api-adapters', '~> 17.3.0'
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
       railties (>= 3.0.0)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (14.1.0)
+    gds-api-adapters (17.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -168,7 +168,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.3.2)
-    rdoc (4.1.1)
+    rdoc (4.2.0)
       json (~> 1.4)
     redis (3.0.7)
     request_store (1.0.6)
@@ -255,7 +255,7 @@ DEPENDENCIES
   capybara (~> 2.4.1)
   database_cleaner (~> 1.3.0)
   factory_girl_rails (~> 4.4.1)
-  gds-api-adapters (~> 14.1.0)
+  gds-api-adapters (~> 17.3.0)
   gds-sso (~> 9.3.0)
   govuk_admin_template (= 1.4.0)
   logstasher (~> 0.5.3)


### PR DESCRIPTION
- This is helpful for simplifying https://github.com/alphagov/short-url-manager/pull/21.
  I'm doing this update in a separate branch due to the fact that
  this app is several major versions behind the most recent.