### PR TITLE
Automatically set the email address to that of the current user

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -15,12 +15,13 @@ class ShortUrlRequestsController < ApplicationController
   end
 
   def new
-    @short_url_request = ShortUrlRequest.new(contact_email: current_user.email, organisation_slug: current_user.organisation_slug)
+    @short_url_request = ShortUrlRequest.new(organisation_slug: current_user.organisation_slug)
   end
 
   def create
     @short_url_request = ShortUrlRequest.new(create_short_url_request_params)
     @short_url_request.requester = current_user
+    @short_url_request.contact_email = current_user.email
 
     if @short_url_request.save
       Notifier.short_url_requested(@short_url_request).deliver
@@ -62,6 +63,6 @@ private
   end
 
   def create_short_url_request_params
-    @create_short_url_request_params ||= params[:short_url_request].permit(:from_path, :to_path, :reason, :contact_email, :organisation_slug)
+    @create_short_url_request_params ||= params[:short_url_request].permit(:from_path, :to_path, :reason, :organisation_slug)
   end
 end

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -15,7 +15,6 @@ class ShortUrlRequest
   has_one :redirect
 
   validates :state, :from_path, :to_path, :reason, :contact_email, :organisation_slug, :organisation_title, presence: true
-  validates :contact_email, format: { with: /\A[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})\z/ }, allow_blank: true
   validates :from_path, :to_path, format: { with: /\A\//, message: 'must be specified as a relative path (eg. "/hmrc/tax-returns")' }, allow_blank: true
   validates :state, inclusion: { in: %w(pending accepted rejected) }, allow_blank: true
 

--- a/app/views/short_url_requests/new.html.erb
+++ b/app/views/short_url_requests/new.html.erb
@@ -27,11 +27,6 @@
       <%= f.text_area :reason, class: 'form-control input-md-8' %>
       <p class="help-block">Please give the reason for this request as requests without a clear and valid reason will be denied. Please also include any other information relevant to this request. As an example if it's related to a non-digital media campaign, please include these details.</p>
     </div>
-
-    <div class="form-group">
-      <%= f.label :contact_email %>
-      <%= f.text_field :contact_email, class: 'form-control input-md-4' %>
-    </div>
   </fieldset>
 
   <fieldset>

--- a/spec/controllers/short_url_requests_controller_spec.rb
+++ b/spec/controllers/short_url_requests_controller_spec.rb
@@ -123,7 +123,6 @@ describe ShortUrlRequestsController do
           from_path: "/a-friendly-url",
           to_path: "/somewhere/a-document",
           reason: "Because wombles",
-          contact_email: "wombles@example.com",
           organisation_slug: organisation.slug
         }
       } }
@@ -134,7 +133,7 @@ describe ShortUrlRequestsController do
         expect(short_url_request.from_path).to          eql params[:short_url_request][:from_path]
         expect(short_url_request.to_path).to            eql params[:short_url_request][:to_path]
         expect(short_url_request.reason).to             eql params[:short_url_request][:reason]
-        expect(short_url_request.contact_email).to      eql params[:short_url_request][:contact_email]
+        expect(short_url_request.contact_email).to      eql user.email
         expect(short_url_request.organisation_slug).to  eql organisation.slug
         expect(short_url_request.organisation_title).to eql organisation.title
       end

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -12,14 +12,12 @@ feature "As a publisher, I can request a short URL" do
     visit "/"
     click_on "Request a new short URL"
 
-    expect(page).to have_field "Contact email", with: "gandalf@example.com"
     expect(page).to have_select "Organisation", selected: "Ministry of Magic"
 
     fill_in "From",          with: from_path = "/some-friendly-url"
     fill_in "To",            with: to_path   = "/government/publications/some-random-publication"
     select "Ministry of Beards", from: "Organisation"
     fill_in "Reason",        with: reason    = "Because of the wombats"
-    fill_in "Contact email", with: email     = "gandalf@example.com"
 
     click_on "Make this request"
 
@@ -29,7 +27,7 @@ feature "As a publisher, I can request a short URL" do
     expect(short_url_request.from_path).to          eql from_path
     expect(short_url_request.to_path).to            eql to_path
     expect(short_url_request.reason).to             eql reason
-    expect(short_url_request.contact_email).to      eql email
+    expect(short_url_request.contact_email).to      eql 'gandalf@example.com'
     expect(short_url_request.organisation_slug).to  eql 'ministry-of-beards'
     expect(short_url_request.organisation_title).to eql 'Ministry of Beards'
 

--- a/spec/models/short_url_request_spec.rb
+++ b/spec/models/short_url_request_spec.rb
@@ -6,8 +6,6 @@ describe ShortUrlRequest do
     specify { expect(build :short_url_request, from_path: '').to_not be_valid }
     specify { expect(build :short_url_request, to_path: '').to_not be_valid }
     specify { expect(build :short_url_request, reason: '').to_not be_valid }
-    specify { expect(build :short_url_request, contact_email: '').to_not be_valid }
-    specify { expect(build :short_url_request, contact_email: 'invalid.email.address').to_not be_valid }
     specify { expect(build :short_url_request, organisation_title: '').to_not be_valid }
     specify { expect(build :short_url_request, organisation_slug: '').to_not be_valid }
 
@@ -16,9 +14,6 @@ describe ShortUrlRequest do
     end
     it "should be invalid when to_path is not a relative path" do
       expect(build :short_url_request, to_path: 'http://www.somewhere.com/a-path').to_not be_valid
-    end
-    it "should be invalid when contact_email is not a valid email address" do
-      expect(build :short_url_request, contact_email: 'invalid.email.address').to_not be_valid
     end
 
     it "should allow 'pending', 'accepted' and 'rejected' as acceptable state values" do


### PR DESCRIPTION
- According to Nayeema, requestors (A) were having problems with
  specifying that the request originated from someone else (B), and
  therefore specifying person B's email address. This meant that
  person A would not get updates about what was essentially their
  requested short URL, and the approvers had to do lots of detective
  work to find out who actually submitted the request through the tool
  (person A) to go and talk to in case of problems or rejection.
- Remove the text field in the new request form and its associated
  validations. Make the tests pass again.

*Screenshots*:

Before:

![screen shot 2015-01-15 at 13 55 56](https://cloud.githubusercontent.com/assets/355033/5758551/45765544-9cbe-11e4-88c4-f40be311dea0.png)

and

![screen shot 2015-01-15 at 13 53 00](https://cloud.githubusercontent.com/assets/355033/5758479/dd1099b0-9cbd-11e4-9751-10d9c94ac58d.png)

After:

![screen shot 2015-01-15 at 13 52 08](https://cloud.githubusercontent.com/assets/355033/5758460/b9a2c674-9cbd-11e4-99c9-3f73586178b5.png)

and

![screen shot 2015-01-15 at 13 53 00](https://cloud.githubusercontent.com/assets/355033/5758479/dd1099b0-9cbd-11e4-9751-10d9c94ac58d.png)

:fire: