### PR TITLE
Change the wording of the From and To boxes and the Reason box help text

### DIFF
--- a/app/views/short_url_requests/_short_url_request_data.html.erb
+++ b/app/views/short_url_requests/_short_url_request_data.html.erb
@@ -5,10 +5,10 @@
   <dt>Requested at:</dt>
   <dd><%= short_url_request.created_at.to_s(:govuk_date) %></dd>
 
-  <dt>From:</dt>
+  <dt>Short URL:</dt>
   <dd><%= short_url_request.from_path %></dd>
 
-  <dt>To:</dt>
+  <dt>Target URL:</dt>
   <dd><%= link_to short_url_request.to_path, govuk_url_for(short_url_request.to_path) %></dd>
 
   <dt>Reason:</dt>

--- a/app/views/short_url_requests/new.html.erb
+++ b/app/views/short_url_requests/new.html.erb
@@ -6,13 +6,13 @@
   <%= render_errors_for @short_url_request, leading_message: "Your request for a short URL could not be made for the following reasons:" %>
   <fieldset>
     <div class="form-group">
-      <%= f.label :from_path, 'From' %>
+      <%= f.label :from_path, 'Short URL' %>
       <%= f.text_field :from_path, class: 'form-control input-md-8' %>
       <p class="help-block">This is the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").</p>
     </div>
 
     <div class="form-group">
-      <%= f.label :to_path, 'To' %>
+      <%= f.label :to_path, 'Target URL' %>
       <%= f.text_field :to_path, class: 'form-control input-md-8' %>
       <p class="help-block">This is the path to redirect the user to. Please specify it as a relative path (eg. "/government/publications/what-hmrc-does-to-prevent-tax-evasion").</p>
     </div>

--- a/app/views/short_url_requests/new.html.erb
+++ b/app/views/short_url_requests/new.html.erb
@@ -25,7 +25,7 @@
     <div class="form-group">
       <%= f.label :reason %>
       <%= f.text_area :reason, class: 'form-control input-md-8' %>
-      <p class="help-block">Please give the reason for this request as requests without a clear and valid reason will be denied. Please also include any other information relevant to this request. As an example if it's related to a non-digital media campaign, please include these details.</p>
+      <p class="help-block">Please explain the reason for this request, as requests without a clear and valid reason will be denied. Please also include any other information relevant to this request such as Zendesk ticket numbers.</p>
     </div>
 
     <div class="form-group">

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -15,8 +15,8 @@ feature "As a publisher, I can request a short URL" do
     expect(page).to have_field "Contact email", with: "gandalf@example.com"
     expect(page).to have_select "Organisation", selected: "Ministry of Magic"
 
-    fill_in "From",          with: from_path = "/some-friendly-url"
-    fill_in "To",            with: to_path   = "/government/publications/some-random-publication"
+    fill_in "Short URL",          with: from_path = "/some-friendly-url"
+    fill_in "Target URL",         with: to_path   = "/government/publications/some-random-publication"
     select "Ministry of Beards", from: "Organisation"
     fill_in "Reason",        with: reason    = "Because of the wombats"
     fill_in "Contact email", with: email     = "gandalf@example.com"


### PR DESCRIPTION
- Some users were getting the From/To URLs the wrong way around, causing
  their requests to be rejected. Following feedback from Nayeema and Elena,
  change these labels to be more descriptive.
- Many requestors deal with departments who want these short URLs via
  Zendesk, and many of them put a link to the Zendesk ticket in the request
  box, so explicitly mention that this is possible.