### PR TITLE
Add a link to the user's profile in Signon to the header

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,11 @@
 
 <% content_for :app_title, "Short URL manager" %>
 
+<% content_for :navbar_right do %>
+  Hello, <%= link_to current_user.name, Plek.current.find('signon') %>
+  &bull; <%= link_to 'Sign out', gds_sign_out_path %>
+<% end %>
+
 <% content_for :content do %>
   <%- unless flash.empty? -%>
     <ul class="flash-messages">


### PR DESCRIPTION
- A user (Elena) demonstrated having to go back through pages to reach Signon to
  switch between applications. This makes it consistent with many (but not all)
  other admin apps, with a link in the top right hand corner of the header,
  therefore on every page.

![screen shot 2015-01-15 at 14 53 27](https://cloud.githubusercontent.com/assets/355033/5759512/570d177c-9cc6-11e4-8076-cd23ba87ef4a.png)
