### PR TITLE
Make the back button on the show page always visible

### DIFF
--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -5,5 +5,5 @@
 <% if @short_url_request.state == 'pending' %>
   <%= button_to "Accept and create redirect", accept_short_url_request_path(@short_url_request), method: :post, class: "btn btn-success" %>
   <%= link_to "Reject", new_rejection_short_url_request_path(@short_url_request), class: "btn btn-danger" %>
-  <%= link_to "Back", short_url_requests_path, class: "btn btn-default" %>
 <% end %>
+<%= link_to "Back", short_url_requests_path, class: "btn btn-default" %>


### PR DESCRIPTION
- Users will presumably always want to get back to the main page, so show it at
  all times not just when a request is pending review.