### PR TITLE
Improve robustness of data import migration.

### DIFF
--- a/db/migrate/20150122161704_import_router_data_short_urls.rb
+++ b/db/migrate/20150122161704_import_router_data_short_urls.rb
@@ -6,6 +6,12 @@ class ImportRouterDataShortUrls < Mongoid::Migration
       from, to, org_slug, reason = row['from'], row['to'], row['org_slug'], row['reason']
 
       puts "Importing #{from} -> #{to}"
+
+      if ShortUrlRequest.where(:state => 'accepted', :from_path => from).exists?
+        puts "  Accepted request already exists, skipping..."
+        next
+      end
+
       req = ShortUrlRequest.new({
         :state => "accepted",
         :from_path => from,


### PR DESCRIPTION
Importing these redirects involves creating items in the content-store.
These requests occasionally timeout, causing the whole migration to
abort.  This adds a retry mechanism to retry each one up to 3 times on a
timeout.