### PR TITLE
Reslug european-growth-funding friendly URL

### DIFF
--- a/db/migrate/20150319115838_fix_european_growth_fund_url.rb
+++ b/db/migrate/20150319115838_fix_european_growth_fund_url.rb
@@ -1,0 +1,21 @@
+class FixEuropeanGrowthFundUrl < Mongoid::Migration
+  SOURCE = "/european-growth-funding"
+  OLD_TARGET = "/england-2014-to-2020-european-structural-and-investment-funds-growth-programme"
+  NEW_TARGET = "/apply-european-structural-investment-funds"
+
+  def self.up
+    if furl = Redirect.where(from_path: SOURCE).first
+      furl.to_path = NEW_TARGET
+      furl.save!
+      puts "Redirecting #{SOURCE} to #{NEW_TARGET}"
+    end
+  end
+
+  def self.down
+    if furl = Redirect.where(from_path: SOURCE).first
+      furl.to_path = OLD_TARGET
+      furl.save!
+      puts "Redirecting #{SOURCE} to #{OLD_TARGET}"
+    end
+  end
+end


### PR DESCRIPTION
This migration updates the app's internal datastore to match changes made manually in production via router-data.

Not to be deployed until after router-data#357