### PR TITLE
Correct the target url for the new ESI fund shurl

### DIFF
--- a/db/migrate/20150319115838_fix_european_growth_fund_url.rb
+++ b/db/migrate/20150319115838_fix_european_growth_fund_url.rb
@@ -1,7 +1,7 @@
 class FixEuropeanGrowthFundUrl < Mongoid::Migration
   SOURCE = "/european-growth-funding"
   OLD_TARGET = "/england-2014-to-2020-european-structural-and-investment-funds-growth-programme"
-  NEW_TARGET = "/apply-european-structural-investment-funds"
+  NEW_TARGET = "/european-structural-investment-funds"
 
   def self.up
     if furl = Redirect.where(from_path: SOURCE).first


### PR DESCRIPTION
This hasn't been deployed, so it should be safe to just correct this
migration, rather than making a brand new one.  Preview won't get the
update, but the database will be blown away by the nightly sync there
shortly, anyway.