### PR TITLE
Remove pagination on the list page in favour of filtering the table

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -11,7 +11,7 @@ class ShortUrlRequestsController < ApplicationController
   end
 
   def list_short_urls
-    @accepted_short_urls = ShortUrlRequest.all.where(state: 'accepted').order_by([:created_at, 'desc']).paginate(page: (params[:page]), per_page: 40)
+    @accepted_short_urls = ShortUrlRequest.all.where(state: 'accepted').order_by([:created_at, 'desc'])
   end
 
   def new

--- a/app/views/short_url_requests/list_short_urls.html.erb
+++ b/app/views/short_url_requests/list_short_urls.html.erb
@@ -1,6 +1,4 @@
-<%= will_paginate @accepted_short_urls %>
-
-<table class="table table-bordered table-hover">
+<table class="table table-bordered table-hover" data-module="filterable-table">
   <thead>
     <tr class="table-header">
       <th>Organisation</th>
@@ -8,6 +6,14 @@
       <th>To</th>
       <th>State</th>
       <th>Date</th>
+    </tr>
+    <tr class="if-no-js-hide table-header-secondary">
+      <td colspan="5">
+        <form>
+          <label for="url-list-filter" class="rm">Filter short URLs</label>
+          <input id="url-list-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter short URLs">
+        </form>
+      </td>
     </tr>
   </thead>
   <% @accepted_short_urls.each do |request| %>
@@ -21,4 +27,3 @@
   <% end %>
 </table>
 
-<%= will_paginate @accepted_short_urls %>

--- a/spec/features/short_url_manager_views_accepted_requests_spec.rb
+++ b/spec/features/short_url_manager_views_accepted_requests_spec.rb
@@ -5,7 +5,7 @@ feature "Short URL manager views accepted short url requests" do
     login_as create(:user, permissions: ['signon', 'manage_short_urls'])
   end
 
-  scenario "Short URL manager the index of short_url requests and uses the pagination" do
+  scenario "Short URL manager the index of short_url requests" do
     create :short_url_request, :accepted, from_path: "/ministry-of-beards",
                           to_path: "/government/organisations/ministry-of-beards",
                           organisation_title: "Ministry of Beards",
@@ -31,11 +31,6 @@ feature "Short URL manager views accepted short url requests" do
 
     expect(page).to have_content "/from/path/2"
     expect(page).to have_content "/from/path/40"
-    expect(page).to have_no_content "/from/path/41"
-
-    click_on "Next", match: :first
-
     expect(page).to have_content "/from/path/41"
-    expect(page).to have_no_content "/from/path/40"
   end
 end


### PR DESCRIPTION
- Unfortunately the table filter JavaScript module doesn't support
  filtering over multiple pages, which would defeat the object of
  having it there. I've therefore made the decision to remove the
  pagination on the "list accepted short URLs page" and add a
  search-like box to make finding a previous short URL a lot easier.

(Roo agrees that this is a good idea. :sunny: Taken most of the code from Transition when we did a [similar thing](https://github.com/alphagov/transition/commit/f8874f086048dc104df0f744355f0d32fff947d9).)

Before:

![screen shot 2015-04-30 at 12 39 47](https://cloud.githubusercontent.com/assets/355033/7412018/1562d236-ef36-11e4-85ba-9e315372b334.png)

After:

![screen shot 2015-04-30 at 12 33 17](https://cloud.githubusercontent.com/assets/355033/7412016/11142bf8-ef36-11e4-9673-139c7725956b.png)

(Of course, the data differences are preview vs. my dev VM's latest replication.)
