### PR TITLE
Add the ability for short URLs to be edited by admins

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -45,10 +45,11 @@ class ShortUrlRequestsController < ApplicationController
   def update
     @short_url_request = ShortUrlRequest.find(params[:id])
 
-    if @short_url_request.update_attributes(short_url_request_params)
+    if @short_url_request.update_attributes(short_url_request_params) && @short_url_request.update!
       flash[:success] = "Your edit was successful."
       redirect_to short_url_request_path(@short_url_request)
     else
+      flash[:error] = "Your edit was unsuccessful – try again."
       render 'edit'
     end
   end

--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -1,6 +1,6 @@
 class ShortUrlRequestsController < ApplicationController
   before_filter :authorise_as_short_url_requester!, only: [:new, :create]
-  before_filter :authorise_as_short_url_manager!, only: [:index, :show, :accept, :new_rejection, :reject, :list_short_urls]
+  before_filter :authorise_as_short_url_manager!, only: [:index, :show, :accept, :new_rejection, :reject, :list_short_urls, :edit, :update]
   before_filter :get_short_url_request, only: [:show, :accept, :new_rejection, :reject]
 
   def index
@@ -19,7 +19,7 @@ class ShortUrlRequestsController < ApplicationController
   end
 
   def create
-    @short_url_request = ShortUrlRequest.new(create_short_url_request_params)
+    @short_url_request = ShortUrlRequest.new(short_url_request_params)
     @short_url_request.requester = current_user
     @short_url_request.contact_email = current_user.email
 
@@ -35,6 +35,21 @@ class ShortUrlRequestsController < ApplicationController
   def accept
     if !@short_url_request.accept!
       render template: 'short_url_requests/accept_failed'
+    end
+  end
+
+  def edit
+    @short_url_request = ShortUrlRequest.find(params[:id])
+  end
+
+  def update
+    @short_url_request = ShortUrlRequest.find(params[:id])
+
+    if @short_url_request.update_attributes(short_url_request_params)
+      flash[:success] = "Your edit was successful."
+      redirect_to short_url_request_path(@short_url_request)
+    else
+      render 'edit'
     end
   end
 
@@ -62,7 +77,7 @@ private
     render text: "Not found", status: 404
   end
 
-  def create_short_url_request_params
-    @create_short_url_request_params ||= params[:short_url_request].permit(:from_path, :to_path, :reason, :organisation_slug)
+  def short_url_request_params
+    @short_url_request_params ||= params[:short_url_request].permit(:from_path, :to_path, :reason, :organisation_slug)
   end
 end

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -34,6 +34,15 @@ class ShortUrlRequest
     end
   end
 
+  def update!
+    short_url = self.redirect
+    if short_url.update_attributes(to_path: to_path)
+      true
+    else
+      false
+    end
+  end
+
   def reject!(reason = nil)
     update_attributes state: 'rejected',
                       rejection_reason: reason

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -1,0 +1,33 @@
+<%= form_for @short_url_request do |f| %>
+  <%= render_errors_for @short_url_request, leading_message: "Your request for a short URL could not be made for the following reasons:" %>
+  <fieldset>
+    <div class="form-group">
+      <%= f.label :from_path, 'Short URL' %>
+      <%= f.text_field :from_path, class: 'form-control input-md-8' %>
+      <p class="help-block">This is the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").</p>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :to_path, 'Target URL' %>
+      <%= f.text_field :to_path, class: 'form-control input-md-8' %>
+      <p class="help-block">This is the path to redirect the user to. Please specify it as a relative path (eg. "/government/publications/what-hmrc-does-to-prevent-tax-evasion").</p>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :organisation_slug, "Organisation" %>
+      <%= f.select :organisation_slug, options_for_select(organisations.map {|org| [org.title, org.slug] }, @short_url_request.organisation_slug), {}, class: 'form-control input-md-6' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :reason %>
+      <%= f.text_area :reason, class: 'form-control input-md-8' %>
+      <p class="help-block">Please explain the reason for this request, as requests without a clear and valid reason will be denied. Please also include any other information relevant to this request such as Zendesk ticket numbers.</p>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <div class="form-group">
+      <%= f.submit "Submit this request", class: 'btn btn-success' %>
+    </div>
+  </fieldset>
+<%- end -%>

--- a/app/views/short_url_requests/edit.html.erb
+++ b/app/views/short_url_requests/edit.html.erb
@@ -1,0 +1,7 @@
+<%= content_for :page_title, 'Edit short URL' %>
+  <h1 class="page-title-with-border">
+      Edit short URL
+  </h1>
+
+  <%= render :partial => 'form' %>
+

--- a/app/views/short_url_requests/new.html.erb
+++ b/app/views/short_url_requests/new.html.erb
@@ -2,36 +2,4 @@
 
 <p>If you are not familiar with requesting short URLs, please read <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">this guidance</a> first.</p>
 
-<%= form_for @short_url_request, url: { action: :create } do |f| %>
-  <%= render_errors_for @short_url_request, leading_message: "Your request for a short URL could not be made for the following reasons:" %>
-  <fieldset>
-    <div class="form-group">
-      <%= f.label :from_path, 'Short URL' %>
-      <%= f.text_field :from_path, class: 'form-control input-md-8' %>
-      <p class="help-block">This is the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").</p>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :to_path, 'Target URL' %>
-      <%= f.text_field :to_path, class: 'form-control input-md-8' %>
-      <p class="help-block">This is the path to redirect the user to. Please specify it as a relative path (eg. "/government/publications/what-hmrc-does-to-prevent-tax-evasion").</p>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :organisation_slug, "Organisation" %>
-      <%= f.select :organisation_slug, options_for_select(organisations.map {|org| [org.title, org.slug] }, @short_url_request.organisation_slug), {}, class: 'form-control input-md-6' %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :reason %>
-      <%= f.text_area :reason, class: 'form-control input-md-8' %>
-      <p class="help-block">Please explain the reason for this request, as requests without a clear and valid reason will be denied. Please also include any other information relevant to this request such as Zendesk ticket numbers.</p>
-    </div>
-  </fieldset>
-
-  <fieldset>
-    <div class="form-group">
-      <%= f.submit "Make this request", class: 'btn btn-success' %>
-    </div>
-  </fieldset>
-<%- end -%>
+<%= render :partial => 'form' %>

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -5,5 +5,7 @@
 <% if @short_url_request.state == 'pending' %>
   <%= button_to "Accept and create redirect", accept_short_url_request_path(@short_url_request), method: :post, class: "btn btn-success" %>
   <%= link_to "Reject", new_rejection_short_url_request_path(@short_url_request), class: "btn btn-danger" %>
+<% elsif @short_url_request.state == 'accepted' %>
+  <%= link_to "Edit", edit_short_url_request_path, class: "btn btn-default" %>
 <% end %>
 <%= link_to "Back", short_url_requests_path, class: "btn btn-default" %>

--- a/spec/controllers/short_url_requests_controller_spec.rb
+++ b/spec/controllers/short_url_requests_controller_spec.rb
@@ -200,6 +200,15 @@ describe ShortUrlRequestsController do
     end
   end
 
+  describe '#edit' do
+    let!(:short_url_request) { create :short_url_request }
+
+    it 'displays the form' do
+      get :edit, id: short_url_request.id
+      expect(response.status).to eql(200)
+    end
+  end
+
   describe "new_rejection" do
     let!(:short_url_request) { create :short_url_request }
     before {

--- a/spec/factories/short_url_request_factories.rb
+++ b/spec/factories/short_url_request_factories.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     sequence(:from_path) { |n| "/short-url-request-from-path-#{n}" }
     sequence(:to_path) { |n| "/short-url-request-to-path-#{n}" }
     sequence(:reason) { |n| "Short URL request reason #{n}" }
-    sequence(:contact_email) { |n| "short-url-requster-#{n}@example.com" }
+    sequence(:contact_email) { |n| "short-url-requester-#{n}@example.com" }
     sequence(:organisation_slug) { |n| "organisation-#{n}" }
     sequence(:organisation_title) { |n| "Organisation #{n}" }
     association :requester, factory: :short_url_requester
@@ -17,5 +17,16 @@ FactoryGirl.define do
     trait :rejected do
       state 'rejected'
     end
+  end
+
+  factory :accepted_short_url_request do
+    sequence(:from_path) { |n| "/short-url-request-from-path-#{n}" }
+    sequence(:to_path) { |n| "/short-url-request-to-path-#{n}" }
+    sequence(:reason) { |n| "Short URL request reason #{n}" }
+    sequence(:contact_email) { |n| "short-url-requester-#{n}@example.com" }
+    sequence(:organisation_slug) { |n| "organisation-#{n}" }
+    sequence(:organisation_title) { |n| "Organisation #{n}" }
+    sequence(:state) { |n| "accepted" }
+    association :requester, factory: :short_url_requester
   end
 end

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -19,7 +19,7 @@ feature "As a publisher, I can request a short URL" do
     select "Ministry of Beards", from: "Organisation"
     fill_in "Reason",        with: reason    = "Because of the wombats"
 
-    click_on "Make this request"
+    click_on "Submit this request"
 
     expect(page).to have_content "Your request has been made."
 

--- a/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api'
 
-feature "Short URL manager responds to short URL requets" do
+feature "Short URL manager responds to short URL requests" do
   include GdsApi::TestHelpers::PublishingApi
   include PublishingApiHelper
 
@@ -13,6 +13,13 @@ feature "Short URL manager responds to short URL requets" do
                                contact_email: "gandalf@example.com",
                                created_at: Time.zone.parse("2014-01-01 12:00:00"),
                                organisation_title: "Ministry of Beards"
+    create :short_url_request, from_path: "/ministry-of-hair",
+                               to_path: "/government/organisations/minstry-of-hair",
+                               reason: "Hair enables beards to exist",
+                               contact_email: "hairy@example.com",
+                               created_at: Time.zone.parse("2014-01-01 12:00:00"),
+                               organisation_title: "Ministry of Hair",
+                               state: "accepted"
     login_as create(:user, permissions: ['signon', 'manage_short_urls'])
   end
 
@@ -49,5 +56,17 @@ feature "Short URL manager responds to short URL requets" do
     expect(mail.to).to eql ['gandalf@example.com']
     expect(mail.subject).to include 'Short URL request denied'
     expect(mail).to have_body_content "Beards are soo last season."
+  end
+
+  scenario "Short URL manager edits a short URL" do
+    visit list_short_urls_path
+
+    click_on "Ministry of Hair"
+    click_on "Edit"
+
+    fill_in "Short URL", with: "/ministry-of-long-hair"
+    click_on "Submit this request"
+
+    expect(page).to have_content("Your edit was successful.")
   end
 end

--- a/spec/models/short_url_request_spec.rb
+++ b/spec/models/short_url_request_spec.rb
@@ -116,6 +116,25 @@ describe ShortUrlRequest do
       end
     end
 
+    describe "update!" do
+      let(:accepted_short_url_request) { create :short_url_request, :state => :accepted }
+      let(:new_short_url) {
+        new_short_url = double
+        allow(new_short_url).to receive(:update_attributes)
+        new_short_url
+      }
+      let!(:return_value) { accepted_short_url_request.update! }
+
+      it "should update an existing redirect, copying :to_path attributes" do
+        expect(accepted_short_url_request).to have_received(:update_attributes).with(hash_including(to_path: short_url_request.to_path))
+        expect(new_short_url).to have_received(:update_attributes)
+      end
+
+      it "should return true, indicating that the destination path change was successful" do
+        expect(return_value).to equal true
+      end
+    end
+
     describe "reject!" do
       before { stub_notification(:short_url_request_rejected) }
 
@@ -127,7 +146,7 @@ describe ShortUrlRequest do
         expect(short_url_request.rejection_reason).to eql "A reason"
       end
 
-      it "should return true, indicating that the state chage was successful" do
+      it "should return true, indicating that the state change was successful" do
         expect(short_url_request.reject!).to equal true
       end
 


### PR DESCRIPTION
- To do this, change some of the wording of the `new` form and make it
  into a `form` partial.
- Test this new behaviour.

Here are some screenshots of the process.

Before:

![screen shot 2015-05-01 at 15 29 47](https://cloud.githubusercontent.com/assets/355033/7431498/f7ded8c2-f016-11e4-85f8-32da446148f9.png)

During:

![screen shot 2015-05-01 at 15 30 00](https://cloud.githubusercontent.com/assets/355033/7431506/08f36452-f017-11e4-905d-72325d876865.png)

After:

![screen shot 2015-05-01 at 15 30 04](https://cloud.githubusercontent.com/assets/355033/7431511/0f66c202-f017-11e4-85a9-baf18e8b4ce8.png)
