### PR TITLE
Update the short URL for /european-growth-funding

### DIFF
--- a/db/migrate/20150715153119_update_european_growth_fund_short_url.rb
+++ b/db/migrate/20150715153119_update_european_growth_fund_short_url.rb
@@ -1,0 +1,33 @@
+class UpdateEuropeanGrowthFundShortUrl < Mongoid::Migration
+  SOURCE = "/european-growth-funding"
+  OLD_TARGET = "/european-structural-investment-funds"
+  NEW_TARGET = "/england-2014-to-2020-european-structural-and-investment-funds"
+
+  def self.up
+    if request = ShortUrlRequest.where(from_path: SOURCE).first
+      request.to_path = NEW_TARGET
+      request.save!
+      puts "Updating request from #{SOURCE} to #{NEW_TARGET}"
+    end
+
+    if redirect = Redirect.where(from_path: SOURCE).first
+      redirect.to_path = NEW_TARGET
+      redirect.save!
+      puts "Redirecting #{SOURCE} to #{NEW_TARGET}"
+    end
+  end
+
+  def self.down
+    if request = ShortUrlRequest.where(from_path: SOURCE).first
+      request.to_path = OLD_TARGET
+      request.save!
+      puts "Updating request from #{SOURCE} to #{OLD_TARGET}"
+    end
+
+    if redirect = Redirect.where(from_path: SOURCE).first
+      redirect.to_path = OLD_TARGET
+      redirect.save!
+      puts "Redirecting #{SOURCE} to #{OLD_TARGET}"
+    end
+  end
+end


### PR DESCRIPTION
The existing Finder (at `/european-structural-investment-funds`) is being replaced
by a detailed guide and the short URL needs to be updated accordingly.

/cc @jamiecobbett 