### PR TITLE
Bump govuk_admin_template to 3.0.0 for GA fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'redis', '3.0.7', require: false # Used by the Organisation importer as a lo
 gem 'mlanett-redis-lock', '0.2.2' # Used by the Organisation importer as a locking mechanism
 gem 'gretel', '3.0.8'
 
-gem 'govuk_admin_template', '2.3.1'
+gem 'govuk_admin_template', '3.0.0'
 gem 'gds-sso', '~> 9.3.0'
 gem 'plek', '~> 1.8.1'
 gem 'gds-api-adapters', '20.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,12 +42,12 @@ GEM
       builder
       multi_json
     arel (6.0.0)
-    autoprefixer-rails (5.2.0.1)
+    autoprefixer-rails (6.0.3)
       execjs
       json
-    bootstrap-sass (3.3.5)
+    bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.2.19)
+      sass (>= 3.3.0)
     bson (2.3.0)
     builder (3.2.2)
     byebug (4.0.5)
@@ -95,7 +95,7 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.3.5)
       activesupport (>= 4.1.0)
-    govuk_admin_template (2.3.1)
+    govuk_admin_template (3.0.0)
       bootstrap-sass (~> 3.3.3)
       jquery-rails (~> 3.1.3)
       rails (>= 3.2.0)
@@ -106,7 +106,7 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    jquery-rails (3.1.3)
+    jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
@@ -289,7 +289,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.4.1)
   gds-api-adapters (= 20.1.1)
   gds-sso (~> 9.3.0)
-  govuk_admin_template (= 2.3.1)
+  govuk_admin_template (= 3.0.0)
   gretel (= 3.0.8)
   logstasher (~> 0.5.3)
   mlanett-redis-lock (= 0.2.2)


### PR DESCRIPTION
Trello: https://trello.com/c/1dS5tgTg/125-fix-analytics-in-all-16-admin-tools

Ensures the Analytics domain is set to the 
`GOVUK_APP_DOMAIN` env variable rather than 
being hardcoded.