### PR TITLE
Add migration to remove redirect

### DIFF
--- a/db/migrate/20151001134351_remove_part_leave_profit_tax_credits_from_database.rb
+++ b/db/migrate/20151001134351_remove_part_leave_profit_tax_credits_from_database.rb
@@ -1,0 +1,17 @@
+class RemovePartLeaveProfitTaxCreditsFromDatabase < Mongoid::Migration
+  def self.up
+    path = '/part-year-profit-tax-credits'
+
+    if short_url_request = ShortUrlRequest.where(from_path: path).first
+      short_url_request.destroy
+    end
+
+    if redirect = Redirect.where(from_path: path).first
+      redirect.destroy
+    end
+  end
+
+  def self.down
+    # Intentionally blank. The removed redirect can be recreated in the web interface if required.
+  end
+end


### PR DESCRIPTION
This redirect was put in place as a temporary measure while a new Smart Answer
was being developed for HMRC.

The new Smart Answer (part-year-profit-tax-credits)[1] was deployed on Tue 29
Sep. Before the deployment we had to change the owner of this path in
url-arbiter from short-url-manager to smartanswers[2].

@jamiecobbett mentioned[3] that we should also remove the redirect from the
short-url-manager database now that it's no longer required.

I've followed the pattern in previous migrations of finding the
`ShortUrlRequest` and `Redirect` records we're interested in.

[1]: https://github.com/alphagov/smart-answers/pull/1942
[2]: https://github.com/alphagov/url-arbiter/pull/25
[3]: https://github.com/alphagov/url-arbiter/pull/25