### PR TITLE
Check if RSpec is defined

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ Rails.application.load_tasks
 
 task :default => :spec
 
-RSpec::Core::RakeTask.new(:validate) do |t|
-  t.pattern = "spec/presenters/publishing_api_presenter_spec.rb"
+if defined?(RSpec)
+  RSpec::Core::RakeTask.new(:validate) do |t|
+    t.pattern = "spec/presenters/publishing_api_presenter_spec.rb"
+  end
 end


### PR DESCRIPTION
Adds a protective clause to check if RSpec is defined, this alleviates problems with rake tasks when RSpec isn't available.
