### PR TITLE
Warn reviewers if an existing redirect is present

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -8,6 +8,7 @@ class ShortUrlRequestsController < ApplicationController
   end
 
   def show
+    @existing_redirect = Redirect.where(from_path: @short_url_request.from_path).first
   end
 
   def list_short_urls

--- a/app/views/short_url_requests/_existing_redirect.html.erb
+++ b/app/views/short_url_requests/_existing_redirect.html.erb
@@ -1,0 +1,5 @@
+<div class="alert alert-danger" id="existing-redirect-warning" role="alert">
+  <strong><%= existing_redirect.from_path %> already redirects to
+    <%= existing_redirect.to_path %>!</strong> Accepting this request will overwrite
+  that.
+</div>

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -2,6 +2,10 @@
 
 <h1>Short URL requested by <%= @short_url_request.organisation_title %></h1>
 
+<% if @short_url_request.state == 'pending' && @existing_redirect.present? %>
+  <%= render 'existing_redirect', existing_redirect: @existing_redirect %>
+<% end %>
+
 <%= render 'short_url_request_data', short_url_request: @short_url_request %>
 
 <% if @short_url_request.state == 'pending' %>

--- a/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
@@ -94,4 +94,26 @@ feature "Short URL manager responds to short URL requests" do
     # publish has already been called once for the original redirect.
     assert_publishing_api_publish(redirect_for_accepted_request.content_id, nil, 2)
   end
+
+  context "when presented with a request that matches an existing redirect short URL" do
+    let!(:pending_request_for_existing_short_url) do
+      create(:short_url_request,
+             :pending,
+             organisation_title: "Ministry of Hair",
+             from_path: "/ministry-of-hair",
+      )
+    end
+
+    scenario "Short URL manager is shown a warning message" do
+      visit short_url_requests_path
+
+      click_on "Ministry of Hair"
+
+      within("#existing-redirect-warning") do
+        expect(page).to have_content accepted_request.from_path
+        expect(page).to have_content accepted_request.to_path
+        expect(page).to have_content "Accepting this request will overwrite that."
+      end
+    end
+  end
 end


### PR DESCRIPTION
Paired with @NeilvB 

[Trello card](https://trello.com/c/D0Ibyt84/36-show-reviewers-if-they-will-overwrite-an-existing-redirect)

<img width="1164" alt="screenshot 2016-08-24 16 20 23" src="https://cloud.githubusercontent.com/assets/615627/17936426/ae87f2c8-6a16-11e6-95f8-0af590534e10.png">

Reviewers can inadvertently overwrite existing short URL's without realising it because there is no immediate feedback that a redirect with the same `from_path` already exists.

Display a warning to the reviewer if accepting the short url request will overwrite an existing, live redirect.

Rather than refactoring the data model to give the history of every short URL request, having talked to Keith this appears to resolve the immediate user need from the reviewers side.

We are running a couple of subsequent stories to warn requesters they are requesting a duplicate to further reduce risk.