### PR TITLE
Fix sporadic failure caused by stale test data

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,9 +23,12 @@ SimpleCov.start 'rails'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.before :each do
+  config.before :suite do
     DatabaseCleaner.strategy = :truncation
-    DatabaseCleaner.start
+    DatabaseCleaner.clean
+  end
+
+  config.before :each do
     ActionMailer::Base.deliveries = []
   end
 


### PR DESCRIPTION
1. Database cleaner should be run before the entire suite, incase some
   data is left over from previous runs.
2. Truncation strategy with `database_cleaner` doesn't require starting.
3. Set the strategy once before the suite, not before each test.