### PR TITLE
Fail validation if an identical redirect exists

### DIFF
--- a/lib/commands/short_url_requests/create.rb
+++ b/lib/commands/short_url_requests/create.rb
@@ -7,7 +7,9 @@ class Commands::ShortUrlRequests::Create
   def call(success:, confirmation_required:, failure:)
     url_request = create_object(params, requester)
 
-    if requires_confirmation?(url_request)
+    if !url_request.valid?
+      failure.call(url_request)
+    elsif requires_confirmation?(url_request)
       confirmation_required.call(url_request)
     elsif url_request.save
       Notifier.short_url_requested(url_request).deliver_now

--- a/spec/lib/commands/short_url_requests/create_spec.rb
+++ b/spec/lib/commands/short_url_requests/create_spec.rb
@@ -73,7 +73,7 @@ describe Commands::ShortUrlRequests::Create do
     end
   end
 
-  context "when a short url already exists" do
+  context "when a similar short url already exists" do
     let(:params) {
       {
         from_path: "/a-friendly-url",
@@ -84,7 +84,7 @@ describe Commands::ShortUrlRequests::Create do
     }
 
     before do
-      create(:redirect, params.slice(:from_path, :to_path))
+      create(:redirect, params.slice(:from_path))
     end
 
     it "calls the confirmation_required callback" do
@@ -95,6 +95,27 @@ describe Commands::ShortUrlRequests::Create do
       )
 
       expect(confirmation_required).to have_received(:call).once.with(instance_of(ShortUrlRequest))
+    end
+
+    context "with invalid data" do
+      let(:params) {
+        {
+          from_path: "/a-friendly-url",
+          to_path: "",
+          reason: "Because wombles",
+          organisation_slug: nil,
+        }
+      }
+
+      it "calls the failure callback" do
+        command.call(
+          success: success,
+          failure: failure,
+          confirmation_required: confirmation_required,
+        )
+
+        expect(failure).to have_received(:call).once.with(instance_of(ShortUrlRequest))
+      end
     end
 
     context "with confirmation" do

--- a/spec/models/short_url_request_spec.rb
+++ b/spec/models/short_url_request_spec.rb
@@ -31,6 +31,14 @@ describe ShortUrlRequest do
       expect(from_path_stripped_whitespace.from_path).to eq('/a-path')
       expect(to_path_stripped_whitespace.to_path).to eq('/b-path')
     end
+
+    context "with a pre-existing redirect" do
+      before { create(:redirect, from_path: '/a-path', to_path: '/b-path') }
+
+      it "is invalid" do
+        expect(build :short_url_request, from_path: '/a-path', to_path: '/b-path').not_to be_valid
+      end
+    end
   end
 
   describe "scopes" do


### PR DESCRIPTION
We don't want to create extra work for reviewers -- prevent raising a
request if a current Redirect already exists with the same from_path and
to_path.

I spotted a bug here in that if validation failed but confirmation was
required the validation wouldn't be checked until the confirmation was
sent, at which point the user is redirected to the form, and the
confirmation is lost, so they have to confirm again. Fix that by
massaging the order (and cover it with a spec).