### PR TITLE
Enable campaign redirects

### DIFF
--- a/app/models/concerns/short_url_validations.rb
+++ b/app/models/concerns/short_url_validations.rb
@@ -3,6 +3,20 @@ module ShortUrlValidations
 
   included do
     validates :from_path, :to_path, presence: true
-    validates :from_path, :to_path, format: { with: /\A\//, message: 'must be specified as a relative path (eg. "/hmrc/tax-returns")' }, allow_blank: true
+    validates :from_path, format: { with: /\A\//, message: 'must be specified as a relative path (eg. "/hmrc/tax-returns")' }, allow_blank: true
+    validate :to_path_is_valid
+  end
+
+  def to_path_is_valid
+    unless to_path.blank? || to_path =~ /\A\// || govuk_campaign_url?(to_path)
+      errors.add(:to_path, 'must be a relative path (eg. "/hmrc/tax-returns") or a gov.uk campaign URL (eg. "https://my-campaign-title.campaign.gov.uk/an-optional-path")')
+    end
+  end
+
+  def govuk_campaign_url?(path)
+    uri = URI.parse(path)
+    uri.host =~ /\A.+\.campaign\.gov\.uk\z/i && ['http', 'https'].include?(uri.scheme)
+  rescue
+    false
   end
 end

--- a/app/models/concerns/short_url_validations.rb
+++ b/app/models/concerns/short_url_validations.rb
@@ -1,0 +1,8 @@
+module ShortUrlValidations
+  extend ActiveSupport::Concern
+
+  included do
+    validates :from_path, :to_path, presence: true
+    validates :from_path, :to_path, format: { with: /\A\//, message: 'must be specified as a relative path (eg. "/hmrc/tax-returns")' }, allow_blank: true
+  end
+end

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -4,6 +4,7 @@ require "securerandom"
 class Redirect
   include Mongoid::Document
   include Mongoid::Timestamps
+  include ShortUrlValidations
 
   field :content_id, type: String
   field :from_path, type: String
@@ -11,8 +12,6 @@ class Redirect
 
   belongs_to :short_url_request
 
-  validates :from_path, :to_path, presence: true
-  validates :from_path, :to_path, format: { with: /\A\//, message: 'must be specified as a relative path (eg. "/hmrc/tax-returns")' }, allow_blank: true
   validates :from_path, uniqueness: true
 
   before_save :create_redirect_in_publishing_api

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -1,6 +1,7 @@
 class ShortUrlRequest
   include Mongoid::Document
   include Mongoid::Timestamps
+  include ShortUrlValidations
 
   field :state, type: String, default: 'pending'
   field :from_path, type: String
@@ -14,8 +15,7 @@ class ShortUrlRequest
   belongs_to :requester, class_name: "User"
   has_one :redirect
 
-  validates :state, :from_path, :to_path, :reason, :contact_email, :organisation_slug, :organisation_title, presence: true
-  validates :from_path, :to_path, format: { with: /\A\//, message: 'must be specified as a relative path (eg. "/hmrc/tax-returns")' }, allow_blank: true
+  validates :state, :reason, :contact_email, :organisation_slug, :organisation_title, presence: true
   validates :state, inclusion: { in: %w(pending accepted rejected) }, allow_blank: true
   validate :not_already_live
 

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -6,19 +6,19 @@
   <%= render_errors_for @short_url_request, leading_message: "Your request for a short URL could not be made for the following reasons:" %>
   <fieldset>
     <div class="form-group">
-      <%= f.label :from_path, 'Short URL' %>
+      <%= f.label :from_path %>
       <%= f.text_field :from_path, disabled: @short_url_request.persisted?, class: 'form-control input-md-8' %>
       <p class="help-block">This is the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").</p>
     </div>
 
     <div class="form-group">
-      <%= f.label :to_path, 'Target URL' %>
+      <%= f.label :to_path %>
       <%= f.text_field :to_path, class: 'form-control input-md-8' %>
       <p class="help-block">This is the path to redirect the user to. Please specify it as a relative path (eg. "/government/publications/what-hmrc-does-to-prevent-tax-evasion").</p>
     </div>
 
     <div class="form-group">
-      <%= f.label :organisation_slug, "Organisation" %>
+      <%= f.label :organisation_slug %>
       <%= f.select :organisation_slug, options_for_select(organisations.map {|org| [org.title, org.slug] }, @short_url_request.organisation_slug), {}, class: 'form-control input-md-6' %>
     </div>
 

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -14,7 +14,11 @@
     <div class="form-group">
       <%= f.label :to_path %>
       <%= f.text_field :to_path, class: 'form-control input-md-8' %>
-      <p class="help-block">This is the path to redirect the user to. Please specify it as a relative path (eg. "/government/publications/what-hmrc-does-to-prevent-tax-evasion").</p>
+      <p class="help-block">This is the path to redirect the user to. The following types of target URL are supported:</p>
+      <ul class="help-block">
+        <li>Internal gov.uk links, eg. <strong>/government/publications/what-hmrc-does-to-prevent-tax-evasion</strong></li>
+        <li>External gov.uk campaign links, eg. <strong>https://my-campaign-title.campaign.gov.uk/an-optional-path</strong></li>
+      </ul>
     </div>
 
     <div class="form-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,4 +20,9 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  mongoid:
+    attributes:
+      short_url_request:
+        from_path: 'Short URL'
+        to_path: 'Target URL'
+        organisation_slug: 'Organisation'

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -6,6 +6,8 @@ describe Redirect do
   include GdsApi::TestHelpers::PublishingApiV2
   include PublishingApiHelper
 
+  include_examples "ShortUrlValidations"
+
   describe "content_id attribute" do
     it "generates its own content ID on creation" do
       expect(subject.content_id).to be_present
@@ -24,26 +26,6 @@ describe Redirect do
     let(:instance) { build(:redirect, non_factory_attrs) }
 
     specify { expect(instance).to be_valid }
-
-    context "without from_path" do
-      let(:non_factory_attrs) { { from_path: '' } }
-      specify { expect(instance).to_not be_valid }
-    end
-
-    context "when 'from_path' is present, but is not a relative path" do
-      let(:non_factory_attrs) { { from_path: 'http://www.somewhere.com/a-path' } }
-      specify { expect(instance).to_not be_valid }
-    end
-
-    context "without to_path" do
-      let(:non_factory_attrs) { { to_path: '' } }
-      specify { expect(instance).to_not be_valid }
-    end
-
-    context "when 'to_path' is present, but is not a relative path" do
-      let(:non_factory_attrs) { { to_path: 'http://www.somewhere.com/a-path' } }
-      specify { expect(instance).to_not be_valid }
-    end
 
     context "with a duplicate `from_path`" do
       before do

--- a/spec/models/short_url_request_spec.rb
+++ b/spec/models/short_url_request_spec.rb
@@ -3,20 +3,13 @@ require 'rails_helper'
 describe ShortUrlRequest do
   include PublishingApiHelper
 
+  include_examples "ShortUrlValidations"
+
   describe "validations:" do
     specify { expect(build :short_url_request).to be_valid }
-    specify { expect(build :short_url_request, from_path: '').to_not be_valid }
-    specify { expect(build :short_url_request, to_path: '').to_not be_valid }
     specify { expect(build :short_url_request, reason: '').to_not be_valid }
     specify { expect(build :short_url_request, organisation_title: '').to_not be_valid }
     specify { expect(build :short_url_request, organisation_slug: '').to_not be_valid }
-
-    it "should be invalid when from_path is not a relative path" do
-      expect(build :short_url_request, from_path: 'http://www.somewhere.com/a-path').to_not be_valid
-    end
-    it "should be invalid when to_path is not a relative path" do
-      expect(build :short_url_request, to_path: 'http://www.somewhere.com/a-path').to_not be_valid
-    end
 
     it "should allow 'pending', 'accepted' and 'rejected' as acceptable state values" do
       expect(build :short_url_request, state: 'pending').to be_valid

--- a/spec/support/shared_examples_for_short_url_validations.rb
+++ b/spec/support/shared_examples_for_short_url_validations.rb
@@ -1,0 +1,35 @@
+shared_examples_for "ShortUrlValidations" do
+  describe "from_path" do
+    it "is required" do
+      expect(build :short_url_request, from_path: '').to_not be_valid
+    end
+
+    it "must be a relative path" do
+      expect(build :short_url_request, from_path: '/a-path').to be_valid
+      expect(build :short_url_request, from_path: 'http://www.somewhere.com/a-path').to_not be_valid
+    end
+  end
+
+  describe "to_path" do
+    it "is required" do
+      expect(build :short_url_request, to_path: '').to_not be_valid
+    end
+
+    it "may be a relative path" do
+      expect(build :short_url_request, to_path: '/a-path').to be_valid
+    end
+
+    it "may be a gov.uk campaign URL" do
+      expect(build :short_url_request, to_path: 'http://my.campaign.gov.uk').to be_valid
+      expect(build :short_url_request, to_path: 'https://my.campaign.gov.uk').to be_valid
+      expect(build :short_url_request, to_path: 'http://my.campaign.gov.uk/path').to be_valid
+      expect(build :short_url_request, to_path: 'https://my.campaign.gov.uk/path').to be_valid
+    end
+
+    it "must be either a relative path or a gov.uk campaign URL" do
+      expect(build :short_url_request, to_path: 'http://www.somewhere.com/a-path').to_not be_valid
+      expect(build :short_url_request, to_path: 'http://.campaign.gov.uk').to_not be_valid
+      expect(build :short_url_request, to_path: 'ftp://my.campaign.gov.uk').to_not be_valid
+    end
+  end
+end


### PR DESCRIPTION
This is a companion to alphagov/publishing-api#531

[Trello card](https://trello.com/c/4vQu6mO4)

## Description

Our content designers need to be able to configure short URLs for gov.uk campaigns. For example, it needs to be possible to set up a redirect from `https://www.gov.uk/campaign-slug` to `http://my-campaign-title.campaign.gov.uk`.

This PR adds that functionality to short-url-manager.

Other changes in this PR:

* Use i18n for field names, so that the field labels match the validation error messages
* Extract the shared validation logic in `ShortUrlRequest` and `Redirect` into a concern
* Extract the shared examples in the specs for `ShortUrlRequest` and `Redirect` into a spec helper

## Screenshots

![screen shot 2016-09-29 at 15 07 31](https://cloud.githubusercontent.com/assets/657807/18957305/869216e8-8656-11e6-9363-5425eb7e9c51.png)

![screen shot 2016-09-29 at 15 07 39](https://cloud.githubusercontent.com/assets/657807/18957310/883ed7ba-8656-11e6-8210-7a44b6c5ac63.png)

![screen shot 2016-09-29 at 15 07 43](https://cloud.githubusercontent.com/assets/657807/18957311/898318d4-8656-11e6-9ae6-1b73e8aacb09.png)