### PR TITLE
Require gov.uk campaign URLs to be served over HTTPS

### DIFF
--- a/app/models/concerns/short_url_validations.rb
+++ b/app/models/concerns/short_url_validations.rb
@@ -15,7 +15,7 @@ module ShortUrlValidations
 
   def govuk_campaign_url?(path)
     uri = URI.parse(path)
-    uri.host =~ /\A.+\.campaign\.gov\.uk\z/i && ['http', 'https'].include?(uri.scheme)
+    uri.host =~ /\A.+\.campaign\.gov\.uk\z/i && uri.scheme == 'https'
   rescue
     false
   end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -6,7 +6,7 @@ describe Redirect do
   include GdsApi::TestHelpers::PublishingApiV2
   include PublishingApiHelper
 
-  include_examples "ShortUrlValidations"
+  include_examples "ShortUrlValidations", :redirect
 
   describe "content_id attribute" do
     it "generates its own content ID on creation" do

--- a/spec/models/short_url_request_spec.rb
+++ b/spec/models/short_url_request_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe ShortUrlRequest do
   include PublishingApiHelper
 
-  include_examples "ShortUrlValidations"
+  include_examples "ShortUrlValidations", :short_url_request
 
   describe "validations:" do
     specify { expect(build :short_url_request).to be_valid }

--- a/spec/support/shared_examples_for_short_url_validations.rb
+++ b/spec/support/shared_examples_for_short_url_validations.rb
@@ -20,15 +20,15 @@ shared_examples_for "ShortUrlValidations" do
     end
 
     it "may be a gov.uk campaign URL" do
-      expect(build :short_url_request, to_path: 'http://my.campaign.gov.uk').to be_valid
       expect(build :short_url_request, to_path: 'https://my.campaign.gov.uk').to be_valid
-      expect(build :short_url_request, to_path: 'http://my.campaign.gov.uk/path').to be_valid
       expect(build :short_url_request, to_path: 'https://my.campaign.gov.uk/path').to be_valid
     end
 
     it "must be either a relative path or a gov.uk campaign URL" do
-      expect(build :short_url_request, to_path: 'http://www.somewhere.com/a-path').to_not be_valid
-      expect(build :short_url_request, to_path: 'http://.campaign.gov.uk').to_not be_valid
+      expect(build :short_url_request, to_path: 'https://www.somewhere.com/a-path').to_not be_valid
+      expect(build :short_url_request, to_path: 'https://.campaign.gov.uk').to_not be_valid
+      expect(build :short_url_request, to_path: 'http://my.campaign.gov.uk').to_not be_valid
+      expect(build :short_url_request, to_path: 'http://my.campaign.gov.uk/path').to_not be_valid
       expect(build :short_url_request, to_path: 'ftp://my.campaign.gov.uk').to_not be_valid
     end
   end

--- a/spec/support/shared_examples_for_short_url_validations.rb
+++ b/spec/support/shared_examples_for_short_url_validations.rb
@@ -1,35 +1,35 @@
-shared_examples_for "ShortUrlValidations" do
+shared_examples_for "ShortUrlValidations" do |klass|
   describe "from_path" do
     it "is required" do
-      expect(build :short_url_request, from_path: '').to_not be_valid
+      expect(build klass, from_path: '').to_not be_valid
     end
 
     it "must be a relative path" do
-      expect(build :short_url_request, from_path: '/a-path').to be_valid
-      expect(build :short_url_request, from_path: 'http://www.somewhere.com/a-path').to_not be_valid
+      expect(build klass, from_path: '/a-path').to be_valid
+      expect(build klass, from_path: 'http://www.somewhere.com/a-path').to_not be_valid
     end
   end
 
   describe "to_path" do
     it "is required" do
-      expect(build :short_url_request, to_path: '').to_not be_valid
+      expect(build klass, to_path: '').to_not be_valid
     end
 
     it "may be a relative path" do
-      expect(build :short_url_request, to_path: '/a-path').to be_valid
+      expect(build klass, to_path: '/a-path').to be_valid
     end
 
     it "may be a gov.uk campaign URL" do
-      expect(build :short_url_request, to_path: 'https://my.campaign.gov.uk').to be_valid
-      expect(build :short_url_request, to_path: 'https://my.campaign.gov.uk/path').to be_valid
+      expect(build klass, to_path: 'https://my.campaign.gov.uk').to be_valid
+      expect(build klass, to_path: 'https://my.campaign.gov.uk/path').to be_valid
     end
 
     it "must be either a relative path or a gov.uk campaign URL" do
-      expect(build :short_url_request, to_path: 'https://www.somewhere.com/a-path').to_not be_valid
-      expect(build :short_url_request, to_path: 'https://.campaign.gov.uk').to_not be_valid
-      expect(build :short_url_request, to_path: 'http://my.campaign.gov.uk').to_not be_valid
-      expect(build :short_url_request, to_path: 'http://my.campaign.gov.uk/path').to_not be_valid
-      expect(build :short_url_request, to_path: 'ftp://my.campaign.gov.uk').to_not be_valid
+      expect(build klass, to_path: 'https://www.somewhere.com/a-path').to_not be_valid
+      expect(build klass, to_path: 'https://.campaign.gov.uk').to_not be_valid
+      expect(build klass, to_path: 'http://my.campaign.gov.uk').to_not be_valid
+      expect(build klass, to_path: 'http://my.campaign.gov.uk/path').to_not be_valid
+      expect(build klass, to_path: 'ftp://my.campaign.gov.uk').to_not be_valid
     end
   end
 end


### PR DESCRIPTION
Related to #62

See also alphagov/publishing-api#534

* Update the `to_path` validations in the `ShortUrlValidations` concern to require HTTPS for gov.uk campaign URLs. This change affects both the `ShortUrlRequest` model and the `Redirect` model.
* Fix bug in rspec shared examples for `ShortUrlValidations`.