### PR TITLE
Use env vars in configs

### DIFF
--- a/app/services/organisation_importer.rb
+++ b/app/services/organisation_importer.rb
@@ -36,7 +36,7 @@ private
   end
 
   def redis
-    redis_config = YAML.load_file(Rails.root.join("config", "redis.yml"))
+    redis_config = YAML.load(ERB.new(File.read(Rails.root.join("config", "redis.yml"))).result)
     Redis.new(redis_config.symbolize_keys)
   end
 end

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,1 +1,8 @@
-# This file written on deploy
+if ENV["ERRBIT_API_KEY"]
+  Airbrake.configure do |config|
+    config.api_key = ENV["ERRBIT_API_KEY"]
+    config.host = "errbit.#{ENV["GOVUK_APP_DOMAIN"]}"
+    config.secure = true
+    config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
+  end
+end

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,5 +1,3 @@
-# This initialiser is overwritten when deployed to preview, staging & production.
-
 GDS::SSO.config do |config|
   config.user_model   = 'User'
   config.oauth_id     = ENV['OAUTH_ID']
@@ -8,15 +6,17 @@ GDS::SSO.config do |config|
 end
 
 
-# In development, if we want to be able to test features that require permissions
-# then we need to override the default permissions for the dummy user inserted by
-# GDS::SSO in the mock_bearer_token strategy.
-#
-# The easiest way to do this is just to override the GDS::SSO test user with a
-# new user we create here.
-#
-GDS::SSO.test_user = User.find_or_create_by(email: 'user@test.example').tap do |u|
-  u.name = 'Test User'
-  u.permissions = ['signin', 'manage_short_urls', 'request_short_urls']
-  u.save!
+if Rails.env.development?
+  # In development, if we want to be able to test features that require permissions
+  # then we need to override the default permissions for the dummy user inserted by
+  # GDS::SSO in the mock_bearer_token strategy.
+  #
+  # The easiest way to do this is just to override the GDS::SSO test user with a
+  # new user we create here.
+  #
+  GDS::SSO.test_user = User.find_or_create_by(email: 'user@test.example').tap do |u|
+    u.name = 'Test User'
+    u.permissions = ['signin', 'manage_short_urls', 'request_short_urls']
+    u.save!
+  end
 end

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,20 +1,18 @@
 development:
   sessions:
     default:
-      database: short_url_manager_development
-      hosts:
-        - localhost:27017
-      options:
-  options:
+      uri: <%= ENV["MONGODB_URI"] %>
 test:
   sessions:
     default:
-      database: short_url_manager_test
-      hosts:
-        - localhost:27017
+      uri: <%= ENV["TEST_MONGODB_URI"] || "mongodb://localhost/short_url_manager_test" %>
       options:
         read: primary
         # In the test environment we lower the retries and retry interval to
         # low amounts for fast failures.
         max_retries: 1
         retry_interval: 0
+production:
+  sessions:
+    default:
+      uri: <%= ENV["MONGODB_URI"] %>

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -1,3 +1,3 @@
-host: 127.0.0.1
-port: 6379
+host: <%= ENV["REDIS_HOST"] || "127.0.0.1" %>
+port: <%= ENV["REDIS_PORT"] || "6379" %>
 namespace: short-url-manager

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,1 +1,11 @@
-# Cron schedule is in the deployment repository. Adding things here will do nothing.
+# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin
+env :PATH, '/usr/local/bin:/usr/bin:/bin'
+
+# We need Rake to use our own environment
+job_type :rake, "cd :path && govuk_setenv short-url-manager bundle exec rake :task :output"
+
+set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
+
+every :day, at: '4am' do
+  rake "organisations:import"
+end


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

This app will be deployed by govuk-app-deployment so config is mostly held in ENV vars now.

Depends on https://github.com/alphagov/govuk-puppet/pull/5103