### PR TITLE
Show similar requests to admins

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@
 @import 'modules/clickable_row';
 @import 'modules/dl';
 @import 'modules/form';
+@import 'modules/other_requests';
 
 @import 'layouts/application';
 

--- a/app/assets/stylesheets/modules/_other_requests.scss
+++ b/app/assets/stylesheets/modules/_other_requests.scss
@@ -1,0 +1,5 @@
+.other-requests {
+  ol {
+    font-size: 85%;
+  }
+}

--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -12,7 +12,7 @@ class ShortUrlRequestsController < ApplicationController
   end
 
   def list_short_urls
-    @accepted_short_urls = ShortUrlRequest.all.where(state: 'accepted').order_by([:created_at, 'desc'])
+    @accepted_short_urls = ShortUrlRequest.accepted.order_by([:created_at, 'desc'])
   end
 
   def new

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -23,6 +23,7 @@ class ShortUrlRequest
   before_validation :strip_whitespace, :only => [:from_path, :to_path]
 
   scope :pending, -> { where(state: "pending") }
+  scope :accepted, -> { where(state: "accepted") }
 
   attr_accessor :confirmed
 

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -27,7 +27,11 @@ class ShortUrlRequest
   attr_accessor :confirmed
 
   def similar_redirects
-    @duplicates ||= Redirect.or({from_path: from_path}, {to_path: to_path})
+    @similar_redirects ||= Redirect.or({from_path: from_path}, {to_path: to_path})
+  end
+
+  def similar_requests
+    @similar_requests ||= ShortUrlRequest.where(from_path: from_path, :id.ne => self.id).order_by([:created_at, :asc])
   end
 
   def pending?

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -16,7 +16,7 @@ class ShortUrlRequest
   has_one :redirect
 
   validates :state, :reason, :contact_email, :organisation_slug, :organisation_title, presence: true
-  validates :state, inclusion: { in: %w(pending accepted rejected) }, allow_blank: true
+  validates :state, inclusion: { in: %w(pending accepted rejected superseded) }, allow_blank: true
   validate :not_already_live
 
   before_validation :retrieve_organisation_title, if: ->{ organisation_slug_changed? }
@@ -44,6 +44,10 @@ class ShortUrlRequest
 
   def rejected?
     state == 'rejected'
+  end
+
+  def superseded?
+    state == 'superseded'
   end
 
 private

--- a/app/views/short_url_requests/_short_url_request_data.html.erb
+++ b/app/views/short_url_requests/_short_url_request_data.html.erb
@@ -5,8 +5,10 @@
   <dt>Requested at:</dt>
   <dd><%= short_url_request.created_at.to_s(:govuk_date) %></dd>
 
-  <dt>Short URL:</dt>
-  <dd><%= short_url_request.from_path %></dd>
+  <% if show_short_url %>
+    <dt>Short URL:</dt>
+    <dd><%= short_url_request.from_path %></dd>
+  <% end %>
 
   <dt>Target URL:</dt>
   <dd><%= link_to short_url_request.to_path, govuk_url_for(short_url_request.to_path) %></dd>

--- a/app/views/short_url_requests/new_rejection.html.erb
+++ b/app/views/short_url_requests/new_rejection.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Reject this short URL request</h1>
 
-<%= render 'short_url_request_data', short_url_request: @short_url_request %>
+<%= render 'short_url_request_data', short_url_request: @short_url_request, show_short_url: true %>
 
 <%= form_for @short_url_request, url: { action: :reject }, method: :post do |f| %>
   <%= render_errors_for @short_url_request, leading_message: "The short URL request could not be rejected for the following reasons:" %>

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -6,7 +6,24 @@
   <%= render 'existing_redirect', existing_redirect: @existing_redirect %>
 <% end %>
 
-<%= render 'short_url_request_data', short_url_request: @short_url_request %>
+<%= render 'short_url_request_data', short_url_request: @short_url_request, show_short_url: true %>
+
+<div class="panel panel-default other-requests">
+  <div class="panel-heading">
+    <h2>Other requests for this short URL</h2>
+  </div>
+  <div class="panel-body">
+    <% if @short_url_request.similar_requests.any? %>
+      <ol>
+        <% @short_url_request.similar_requests.each do |similar_request| %>
+          <li><%= render 'short_url_request_data', short_url_request: similar_request, show_short_url: false %></li>
+        <% end %>
+      </ol>
+    <% else %>
+      <p>None</p>
+    <% end %>
+  </div>
+</div>
 
 <% if @short_url_request.state == 'pending' %>
   <%= button_to "Accept and create redirect", accept_short_url_request_path(@short_url_request), method: :post, class: "btn btn-success add-right-margin" %>

--- a/db/migrate/20161122132139_move_accepted_requests_without_redirects_to_superseded.rb
+++ b/db/migrate/20161122132139_move_accepted_requests_without_redirects_to_superseded.rb
@@ -1,0 +1,26 @@
+class MoveAcceptedRequestsWithoutRedirectsToSuperseded < Mongoid::Migration
+  class LocalRedirect
+    include Mongoid::Document
+    store_in collection: 'redirects'
+    belongs_to :short_url_request, foreign_key: :short_url_request_id, class_name: 'MoveAcceptedRequestsWithoutRedirectsToSuperseded::LocalShortUrlRequest'
+  end
+
+  class LocalShortUrlRequest
+    include Mongoid::Document
+    store_in collection: 'short_url_requests'
+    has_one :redirect, foreign_key: :short_url_request_id, class_name: 'MoveAcceptedRequestsWithoutRedirectsToSuperseded::LocalRedirect'
+    field :state, type: String
+  end
+
+  def self.up
+    LocalShortUrlRequest.where(state: 'accepted').each do |request|
+      request.update_attributes(state: 'superseded') if request.redirect.nil?
+    end
+  end
+
+  def self.down
+    LocalShortUrlRequest.where(state: 'superseded').each do |request|
+      request.update_attributes(state: 'accepted') if request.redirect.nil?
+    end
+  end
+end

--- a/lib/commands/short_url_requests/accept.rb
+++ b/lib/commands/short_url_requests/accept.rb
@@ -5,9 +5,16 @@ class Commands::ShortUrlRequests::Accept
 
   def call(failure:)
     redirect = Redirect.find_or_initialize_by(from_path: url_request.from_path)
+    # NOTE: we get the target of the relation because otherwise we are holding
+    # a proxy object that will update after we set the url_request in the
+    # update_attributes call below
+    # NOTE 2: this looks like it could be replaced with `.try(:target)` but it
+    # can't as the tests fail - seems the `try` version still retains a proxy
+    existing_request = redirect.short_url_request.nil? ? nil : redirect.short_url_request.target
 
     if redirect.update_attributes(to_path: url_request.to_path, short_url_request: url_request)
       url_request.update_attribute(:state, 'accepted')
+      existing_request.update_attribute(:state, 'superseded') if existing_request.present?
       Notifier.short_url_request_accepted(url_request).deliver_now
     else
       failure.call

--- a/spec/factories/short_url_request_factories.rb
+++ b/spec/factories/short_url_request_factories.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     trait :pending do
       state 'pending'
     end
+
     trait :accepted do
       state 'accepted'
 
@@ -24,8 +25,13 @@ FactoryGirl.define do
                                   to_path: request.to_path)
       end
     end
+
     trait :rejected do
       state 'rejected'
+    end
+
+    trait :superseded do
+      state 'superseded'
     end
   end
 end

--- a/spec/features/short_url_manager_views_accepted_requests_spec.rb
+++ b/spec/features/short_url_manager_views_accepted_requests_spec.rb
@@ -13,6 +13,7 @@ feature "Short URL manager views accepted short url requests" do
 
     create :short_url_request, :pending, from_path: "/from/pending"
     create :short_url_request, :rejected, from_path: "/from/rejected"
+    create :short_url_request, :superseded, from_path: "/from/superseded"
 
     40.times do |n|
       create :short_url_request, :accepted, from_path: "/from/path/#{n+2}",
@@ -28,6 +29,7 @@ feature "Short URL manager views accepted short url requests" do
 
     expect(page).to have_no_content "/from/pending"
     expect(page).to have_no_content "/from/rejected"
+    expect(page).to have_no_content "/from/superseded"
 
     expect(page).to have_content "/from/path/2"
     expect(page).to have_content "/from/path/40"

--- a/spec/features/short_url_manager_views_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_views_furl_requests_spec.rb
@@ -53,6 +53,58 @@ feature "Short URL manager finds information on short_url requests" do
     expect(page).to have_content "gandalf@example.com"
   end
 
+  scenario "Short URL manager shows the details of simialr fRUL requests" do
+    create :short_url_request, from_path: "/ministry-of-beards",
+                          to_path: "/government/organisations/ministry-of-beards",
+                          reason: "Beards are now their own department",
+                          contact_email: "gandalf@example.com",
+                          created_at: Time.zone.parse("2014-01-01 12:00:00"),
+                          organisation_title: "Ministry of Beards"
+    create :short_url_request, from_path: "/ministry-of-beards",
+                          to_path: "/government/organisations/ministry-of-facial-hair",
+                          reason: "Facial Hair department is all about beards",
+                          contact_email: "saruman@example.com",
+                          created_at: Time.zone.parse("2013-01-01 12:00:00"),
+                          organisation_title: "Ministry of Facial Hair"
+    create :short_url_request, from_path: "/ministry-of-bears",
+                          to_path: "/government/organisations/ministry-of-bears",
+                          reason: "Because we really need to think about bears",
+                          contact_email: "beorn@example.com",
+                          created_at: Time.zone.parse("2013-11-01 12:00:00"),
+                          organisation_title: "Ministry of Bears"
+
+    visit short_url_requests_path
+
+    click_on "Ministry of Beards"
+
+
+    within '.other-requests' do
+      # Don't have the main request in the other requests section
+      expect(page).not_to have_content "Ministry of Beards"
+      expect(page).not_to have_content "12:00pm, 1 January 2014"
+      expect(page).not_to have_content "/ministry-of-beards"
+      expect(page).not_to have_link "/government/organisations/ministry-of-beards", href: "http://www.dev.gov.uk/government/organisations/ministry-of-beards"
+      expect(page).not_to have_content "Beards are now their own department"
+      expect(page).not_to have_content "gandalf@example.com"
+
+      # Do have a relevant other request
+      expect(page).to have_content "Ministry of Facial Hair"
+      expect(page).to have_content "12:00pm, 1 January 2013"
+      expect(page).to have_content "/ministry-of-facial-hair"
+      expect(page).to have_link "/government/organisations/ministry-of-facial-hair", href: "http://www.dev.gov.uk/government/organisations/ministry-of-facial-hair"
+      expect(page).to have_content "Facial Hair department is all about beards"
+      expect(page).to have_content "saruman@example.com"
+
+      # Don't have an irrelevant other request
+      expect(page).not_to have_content "Ministry of Bears"
+      expect(page).not_to have_content "12:00pm, 1 Novemeber 2013"
+      expect(page).not_to have_content "/ministry-of-bears"
+      expect(page).not_to have_link "/government/organisations/ministry-of-bears", href: "http://www.dev.gov.uk/government/organisations/ministry-of-bears"
+      expect(page).not_to have_content "Because we really need to think about bears"
+      expect(page).not_to have_content "beorn@example.com"
+    end
+  end
+
   scenario "User without manage_short_urls permission sees no option to manage short_url requests" do
     login_as create(:user, permissions: ['signon'])
     visit "/"

--- a/spec/lib/commands/short_url_requests/accept_spec.rb
+++ b/spec/lib/commands/short_url_requests/accept_spec.rb
@@ -17,7 +17,7 @@ describe Commands::ShortUrlRequests::Accept do
     it "changes request state to accepted" do
       command.call(failure: failure)
 
-      expect(url_request.state).to eq("accepted")
+      expect(url_request).to be_accepted
     end
   end
 
@@ -37,6 +37,20 @@ describe Commands::ShortUrlRequests::Accept do
       redirect.reload
 
       expect(redirect.short_url_request).to eq(url_request)
+    end
+
+    it "marks the existing request as superseded" do
+      command.call(failure: failure)
+      other_request.reload
+
+      expect(other_request).to be_superseded
+    end
+
+    it "marks the new request as accepted" do
+      command.call(failure: failure)
+      url_request.reload
+
+      expect(url_request).to be_accepted
     end
   end
 end

--- a/spec/models/short_url_request_spec.rb
+++ b/spec/models/short_url_request_spec.rb
@@ -36,7 +36,7 @@ describe ShortUrlRequest do
   end
 
   describe "scopes" do
-    describe "pending" do
+    describe ".pending" do
       context "with short_url_requests in different states" do
         let!(:pending_short_url_request) { create(:short_url_request, :pending) }
         let!(:accepted_short_url_request) { create(:short_url_request, :accepted) }
@@ -45,6 +45,19 @@ describe ShortUrlRequest do
 
         it "should only include pending requests" do
           expect(ShortUrlRequest.pending).to be == [pending_short_url_request]
+        end
+      end
+    end
+
+    describe ".accepted" do
+      context "with short_url_requests in different states" do
+        let!(:pending_short_url_request) { create(:short_url_request, :pending) }
+        let!(:accepted_short_url_request) { create(:short_url_request, :accepted) }
+        let!(:rejected_short_url_request) { create(:short_url_request, :rejected) }
+        let!(:superseded_short_url_request) { create(:short_url_request, :superseded) }
+
+        it "should only include accepted requests" do
+          expect(ShortUrlRequest.accepted).to be == [accepted_short_url_request]
         end
       end
     end

--- a/spec/models/short_url_request_spec.rb
+++ b/spec/models/short_url_request_spec.rb
@@ -11,10 +11,11 @@ describe ShortUrlRequest do
     specify { expect(build :short_url_request, organisation_title: '').to_not be_valid }
     specify { expect(build :short_url_request, organisation_slug: '').to_not be_valid }
 
-    it "should allow 'pending', 'accepted' and 'rejected' as acceptable state values" do
+    it "should allow 'pending', 'accepted', 'rejected', and 'superseded' as acceptable state values" do
       expect(build :short_url_request, state: 'pending').to be_valid
       expect(build :short_url_request, state: 'accepted').to be_valid
       expect(build :short_url_request, state: 'rejected').to be_valid
+      expect(build :short_url_request, state: 'superseded').to be_valid
       expect(build :short_url_request, state: 'liquid').to_not be_valid
     end
 
@@ -40,6 +41,7 @@ describe ShortUrlRequest do
         let!(:pending_short_url_request) { create(:short_url_request, :pending) }
         let!(:accepted_short_url_request) { create(:short_url_request, :accepted) }
         let!(:rejected_short_url_request) { create(:short_url_request, :rejected) }
+        let!(:superseded_short_url_request) { create(:short_url_request, :superseded) }
 
         it "should only include pending requests" do
           expect(ShortUrlRequest.pending).to be == [pending_short_url_request]
@@ -71,6 +73,9 @@ describe ShortUrlRequest do
 
     specify { expect(build(:short_url_request, state: 'rejected').rejected?).to be true }
     specify { expect(build(:short_url_request, state: 'accepted').rejected?).to be false }
+
+    specify { expect(build(:short_url_request, state: 'superseded').superseded?).to be true }
+    specify { expect(build(:short_url_request, state: 'accepted').superseded?).to be false }
   end
 
   describe '#similar_requests' do


### PR DESCRIPTION
For: https://trello.com/c/BJ5KTi8V/19-display-associated-requests-on-short-url-page

We want to show other requests for the same short url on the request page to give the user some context on what they might be about to overwrite if they accept this request.  We also change the system to mark any existing requests as 'superseded' when we accept a new request that overwrites it.

There are some extra notes in the commits, so worth reviewing commit-by-commit.

## Screenshots

### No requests

![gov uk - short url manager - no requests](https://cloud.githubusercontent.com/assets/608/20925659/fd8598c2-bbaf-11e6-8eca-3836a22f2cd6.jpg)

### Some requests

![gov uk - short url manager - a request](https://cloud.githubusercontent.com/assets/608/20925660/02519086-bbb0-11e6-8026-b829a80e82bb.jpg)
