### PR TITLE
Change default govuk-content-schemas branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,7 +4,7 @@ set -e
 
 # Clone govuk-content-schemas depedency for contract tests
 rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+git clone --branch deployed-to-production git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
 export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
 
 export RAILS_ENV=test


### PR DESCRIPTION
Change the branch from master to deployed-to-production. This will help
prevent changes being merged in to the Short URL Manager app that don't
work with the currently deployed govuk-content-schemas (this changes
comes from GOV.UK RFC 59).