### PR TITLE
Send document_type/schema_name to publishing-api.

### DIFF
--- a/app/presenters/publishing_api.rb
+++ b/app/presenters/publishing_api.rb
@@ -4,7 +4,8 @@ module Presenters
       {
         "content_id" => redirect.content_id,
         "base_path" => redirect.from_path,
-        "format" => "redirect",
+        "document_type" => "redirect",
+        "schema_name" => "redirect",
         "publishing_app" => "short-url-manager",
         "update_type" => "major",
         "redirects" => [

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,7 @@ Bundler.require(*Rails.groups)
 
 module ShortUrlManager
   class Application < Rails::Application
-    config.autoload_paths += %W(#{config.root}/app #{config.root}/lib)
+    config.eager_load_paths += %W(#{config.root}/app #{config.root}/lib)
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/spec/presenters/publishing_api_presenter_spec.rb
+++ b/spec/presenters/publishing_api_presenter_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Presenters::PublishingAPI do
     expect(presented).to eq(
       "content_id" => redirect.content_id,
       "base_path" => "/from/path",
-      "format" => "redirect",
+      "schema_name" => "redirect",
+      "document_type" => "redirect",
       "publishing_app" => "short-url-manager",
       "update_type" => "major",
       "redirects" => [

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -3,7 +3,8 @@ module PublishingApiHelper
     {
       "content_id" => content_id,
       "base_path" => from_path,
-      "format" => "redirect",
+      "document_type" => "redirect",
+      "schema_name" => "redirect",
       "publishing_app" => "short-url-manager",
       "update_type" => "major",
       "redirects" => [


### PR DESCRIPTION
Schemas no longer accept the "format" field, so this app was trying to send invalid data.

This probably wasn't picked up by the schema tests because this app is not yet running on Jenkins-2.