### PR TITLE
Indicate environment in emails

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -5,21 +5,33 @@ class Notifier < ActionMailer::Base
   def short_url_requested(short_url_request)
     @short_url_request = short_url_request
     to = User.short_url_managers.map &:email
-    subject = "Short URL request for '#{short_url_request.from_path}' by #{short_url_request.organisation_title}"
+    subject = "#{prefix}Short URL request for '#{short_url_request.from_path}' by #{short_url_request.organisation_title}"
     mail to: to, subject: subject
   end
 
   def short_url_request_accepted(short_url_request)
     @short_url_request = short_url_request
     to = Array(short_url_request.contact_email)
-    subject = "Short URL request approved"
+    subject = "#{prefix}Short URL request approved"
     mail to: to, subject: subject
   end
 
   def short_url_request_rejected(short_url_request)
     @short_url_request = short_url_request
     to = Array(short_url_request.contact_email)
-    subject = "Short URL request denied"
+    subject = "#{prefix}Short URL request denied"
     mail to: to, subject: subject
+  end
+
+private
+
+  def prefix
+    "[#{Rails.application.config.instance_name}] " unless production?
+  end
+
+  def production?
+    # We don't set this on the production environment, but we do on all
+    # others (dev VM, test, integration, staging)
+    Rails.application.config.instance_name.blank?
   end
 end

--- a/app/views/notifier/short_url_requested.html.erb
+++ b/app/views/notifier/short_url_requested.html.erb
@@ -24,5 +24,6 @@
       <dt>Reason:</dt>
       <dd><%= @short_url_request.reason %></dd>
     </dl>
+    <p>You can respond to this request here: <%= link_to nil, govuk_url_for(short_url_request_url(@short_url_request, only_path: true)) %></p>
   </body>
 </html>

--- a/app/views/notifier/short_url_requested.text.erb
+++ b/app/views/notifier/short_url_requested.text.erb
@@ -18,3 +18,6 @@ Organisation:
 
 Reason:
 <%= @short_url_request.reason %>
+
+You can respond to this request here:
+<%= govuk_url_for(short_url_request_url(@short_url_request, only_path: true)) %>

--- a/config/initializers/instance_name.rb
+++ b/config/initializers/instance_name.rb
@@ -1,0 +1,7 @@
+# Human-friendly name for this signon instance. This is used when generating
+# emails that need to disambiguate between instances.
+if Rails.env.development? || Rails.env.test?
+  Rails.application.config.instance_name = "development"
+else
+  Rails.application.config.instance_name = ENV.fetch("INSTANCE_NAME", nil)
+end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -50,6 +50,10 @@ describe Notifier do
       expect(mail).to have_body_content "Reason: #{short_url_request_reason}"
     end
 
+    it "includes a link to the short url request" do
+      expect(mail).to have_body_content "You can respond to this request here: #{Plek.current.website_uri + short_url_request_path(short_url_request)}"
+    end
+
     context "with several users with permissions to manage short_urls" do
       let!(:users) { 3.times.map { create :short_url_manager } }
 


### PR DESCRIPTION
We want to let the user know which environment sent the email they receive, particularly in the case of the "short url requested" emails, so people know if they can ignore it because it's not a production one.

For: https://trello.com/c/SAcBmzf3/85-include-indication-of-which-environment-sent-the-email-in-short-url-manager

See: https://github.com/alphagov/govuk-puppet/pull/5338 which adds the env var we need.