### PR TITLE
Use correct host for links to short url requests in notification emails

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -2,4 +2,8 @@ module UrlHelper
   def govuk_url_for(path)
     (Plek.current.website_uri + path).to_s
   end
+
+  def short_url_manger_url_for(path)
+    (Plek.current.find('short-url-manager') + path).to_s
+  end
 end

--- a/app/views/notifier/short_url_requested.html.erb
+++ b/app/views/notifier/short_url_requested.html.erb
@@ -24,6 +24,6 @@
       <dt>Reason:</dt>
       <dd><%= @short_url_request.reason %></dd>
     </dl>
-    <p>You can respond to this request here: <%= link_to nil, govuk_url_for(short_url_request_url(@short_url_request, only_path: true)) %></p>
+    <p>You can respond to this request here: <%= link_to nil, short_url_manger_url_for(short_url_request_url(@short_url_request, only_path: true)) %></p>
   </body>
 </html>

--- a/app/views/notifier/short_url_requested.text.erb
+++ b/app/views/notifier/short_url_requested.text.erb
@@ -20,4 +20,4 @@ Reason:
 <%= @short_url_request.reason %>
 
 You can respond to this request here:
-<%= govuk_url_for(short_url_request_url(@short_url_request, only_path: true)) %>
+<%= short_url_manger_url_for(short_url_request_url(@short_url_request, only_path: true)) %>

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -6,4 +6,10 @@ describe UrlHelper do
       expect(govuk_url_for('/some/path')).to eql 'http://www.dev.gov.uk/some/path'
     end
   end
+
+  describe "short_url_manger_url_for" do
+    it "should return a fully qualified admin url from the given path" do
+      expect(short_url_manger_url_for('/some/path')).to eql 'http://short-url-manager.dev.gov.uk/some/path'
+    end
+  end
 end

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -51,7 +51,7 @@ describe Notifier do
     end
 
     it "includes a link to the short url request" do
-      expect(mail).to have_body_content "You can respond to this request here: #{Plek.current.website_uri + short_url_request_path(short_url_request)}"
+      expect(mail).to have_body_content "You can respond to this request here: #{Plek.current.find('short-url-manager') + short_url_request_path(short_url_request)}"
     end
 
     context "with several users with permissions to manage short_urls" do


### PR DESCRIPTION
These urls are hosted on the short-url-manager domain, not the public www
domain.  We could solve this by setting default_url_options on the mailer
but as we generat two types of urls (public and admin) it's not obvious
which host should be the default.  It's probably better to set neither
and force us to be specific when generating all urls.