### PR TITLE
Require signin permission

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   include GDS::SSO::ControllerMethods
-  before_action :authenticate_user!
+  before_action :require_signin_permission!
 
 private
 

--- a/spec/controllers/short_url_requests_controller_spec.rb
+++ b/spec/controllers/short_url_requests_controller_spec.rb
@@ -2,12 +2,12 @@ require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api_v2'
 
 describe ShortUrlRequestsController do
-  let(:user) { create(:user, permissions: %w(signon request_short_urls manage_short_urls)) }
+  let(:user) { create(:short_url_requester_and_manager) }
   before { login_as user }
 
   describe "access control" do
     context "with a user without request_short_urls permission" do
-      let(:user) { create(:user, permissions: %w(signon manage_short_urls)) }
+      let(:user) { create(:short_url_manager) }
 
       specify {
         expect_not_authorised(:get, :new)
@@ -16,7 +16,7 @@ describe ShortUrlRequestsController do
     end
 
     context "with a user without manage_short_urls permission" do
-      let(:user) { create(:user, permissions: %w(signon request_short_urls)) }
+      let(:user) { create(:short_url_requester) }
 
       specify {
         expect_not_authorised(:get, :index)
@@ -102,7 +102,7 @@ describe ShortUrlRequestsController do
 
     context "with a user with an organisation" do
       let!(:organisation) { create(:organisation) }
-      let(:user) { create(:user, permissions: %w(signon request_short_urls manage_short_urls), organisation_slug: organisation.slug) }
+      let(:user) { create(:short_url_requester_and_manager, organisation_slug: organisation.slug) }
 
       it "should assign a new ShortUrlRequest with the organisation_slug set to the current user's organisaiton" do
         expect(assigns[:short_url_request]).to_not be_nil

--- a/spec/factories/user_factories.rb
+++ b/spec/factories/user_factories.rb
@@ -11,4 +11,8 @@ FactoryGirl.define do
   factory :short_url_manager, parent: :user do
     permissions %w(signon manage_short_urls)
   end
+
+  factory :short_url_requester_and_manager, parent: :user do
+    permissions %w(signon request_short_urls manage_short_urls)
+  end
 end

--- a/spec/factories/user_factories.rb
+++ b/spec/factories/user_factories.rb
@@ -1,18 +1,18 @@
 FactoryGirl.define do
   factory :user do
-    permissions ['signon']
+    permissions ['signin']
     sequence(:email) { |n| "user-#{n}@example.com" }
   end
 
   factory :short_url_requester, parent: :user do
-    permissions %w(signon request_short_urls)
+    permissions %w(signin request_short_urls)
   end
 
   factory :short_url_manager, parent: :user do
-    permissions %w(signon manage_short_urls)
+    permissions %w(signin manage_short_urls)
   end
 
   factory :short_url_requester_and_manager, parent: :user do
-    permissions %w(signon request_short_urls manage_short_urls)
+    permissions %w(signin request_short_urls manage_short_urls)
   end
 end

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -4,8 +4,8 @@ feature "As a publisher, I can request a short URL" do
   background do
     create :organisation, title: 'Ministry of Magic', slug: 'ministry-of-magic'
     create :organisation, title: 'Ministry of Beards', slug: 'ministry-of-beards'
-    create :user, email: "short-url-manager-1@example.com", permissions: %w(signon manage_short_urls)
-    login_as create(:user, permissions: %w(signon request_short_urls), name: "Gandalf", email: "gandalf@example.com", organisation_slug: "ministry-of-magic")
+    create :short_url_manager, email: "short-url-manager-1@example.com"
+    login_as create(:short_url_requester, name: "Gandalf", email: "gandalf@example.com", organisation_slug: "ministry-of-magic")
   end
 
   scenario "Publisher requests a short_url, and short_url managers are notified" do
@@ -38,7 +38,7 @@ feature "As a publisher, I can request a short URL" do
   end
 
   scenario "User without request_short_urls permission sees no option to request a short_url" do
-    login_as create(:user, permissions: ['signon'])
+    login_as create(:user)
     visit "/"
     expect(page).to have_no_content('Request a new short URL')
   end

--- a/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
@@ -7,7 +7,7 @@ feature "Short URL manager responds to short URL requests" do
 
   background do
     stub_any_publishing_api_call
-    login_as create(:user, permissions: %w(signon manage_short_urls))
+    login_as create(:short_url_manager)
   end
 
   let!(:pending_request) do

--- a/spec/features/short_url_manager_views_accepted_requests_spec.rb
+++ b/spec/features/short_url_manager_views_accepted_requests_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature "Short URL manager views accepted short url requests" do
   background do
-    login_as create(:user, permissions: %w(signon manage_short_urls))
+    login_as create(:short_url_manager)
   end
 
   scenario "Short URL manager the index of short_url requests" do

--- a/spec/features/short_url_manager_views_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_views_furl_requests_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 feature "Short URL manager finds information on short_url requests" do
   background do
-    login_as create(:user, permissions: %w(signon manage_short_urls))
+    login_as create(:short_url_manager)
   end
 
   scenario "Short URL manager views the index of short_url requests and uses the pagination" do
@@ -106,7 +106,7 @@ feature "Short URL manager finds information on short_url requests" do
   end
 
   scenario "User without manage_short_urls permission sees no option to manage short_url requests" do
-    login_as create(:user, permissions: ['signon'])
+    login_as create(:user)
     visit "/"
     expect(page).to have_no_content('View pending requests')
   end


### PR DESCRIPTION
For: https://trello.com/c/6yS2fcZ4/111-fix-short-url-manager-so-it-properly-respects-signon-signin-permission

Make sure we require 'signin' permission for people logging in to short-url-manager.  Without this unchecking the "access" checkbox in the signon UI would make admins think that someone can't login when in fact they still can.  If they don't have other permissions this isn't a huge problem, but if they do this might mean someone we don't want to be using the system to request or manage short urls is still able to.

Almost every other signon app requires 'signin' permission, and the `mock_gds_sso` strategy used in tests and development mode forces 'signin' permission on the user when it fakes the login.