### PR TITLE
Govuk subdomains

### DIFF
--- a/app/models/concerns/short_url_validations.rb
+++ b/app/models/concerns/short_url_validations.rb
@@ -9,7 +9,7 @@ module ShortUrlValidations
 
   def to_path_is_valid
     unless to_path.blank? || to_path =~ /\A\// || govuk_subdomain_url?(to_path)
-      errors.add(:to_path, 'must be a relative path (eg. "/hmrc/tax-returns") or a gov.uk campaign URL (eg. "https://my-campaign-title.campaign.gov.uk/an-optional-path")')
+      errors.add(:to_path, 'must be a relative path (eg. "/hmrc/tax-returns") or a gov.uk redirect URL (eg. "https://my-title.service.gov.uk/an-optional-path")')
     end
   end
 

--- a/app/models/concerns/short_url_validations.rb
+++ b/app/models/concerns/short_url_validations.rb
@@ -8,14 +8,14 @@ module ShortUrlValidations
   end
 
   def to_path_is_valid
-    unless to_path.blank? || to_path =~ /\A\// || govuk_campaign_url?(to_path)
+    unless to_path.blank? || to_path =~ /\A\// || govuk_subdomain_url?(to_path)
       errors.add(:to_path, 'must be a relative path (eg. "/hmrc/tax-returns") or a gov.uk campaign URL (eg. "https://my-campaign-title.campaign.gov.uk/an-optional-path")')
     end
   end
 
-  def govuk_campaign_url?(path)
+  def govuk_subdomain_url?(path)
     uri = URI.parse(path)
-    uri.host =~ /\A.+\.campaign\.gov\.uk\z/i && uri.scheme == 'https'
+    uri.host =~ /\A([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\.)*gov\.uk\z/i && uri.scheme == 'https'
   rescue
     false
   end

--- a/app/views/dashboard/dashboard.html.erb
+++ b/app/views/dashboard/dashboard.html.erb
@@ -8,6 +8,6 @@
   <% end %>
   <% if current_user.can_manage_short_urls? %>
     <li class="list-group-item"><%= link_to "View pending requests", short_url_requests_path %></li>
-    <li class="list-group-item"><%= link_to "View live short URLs", list_short_urls_path %></li>
+    <li class="list-group-item"><%= link_to "View live redirect URLs and short URLs", list_short_urls_path %></li>
   <% end %>
 </ul>

--- a/app/views/dashboard/dashboard.html.erb
+++ b/app/views/dashboard/dashboard.html.erb
@@ -4,7 +4,7 @@
 
 <ul class="list-group col-md-6">
   <% if current_user.can_request_short_urls? %>
-    <li class="list-group-item"><%= link_to "Request a new short URL", new_short_url_request_path %></li>
+    <li class="list-group-item"><%= link_to "Request a new URL redirect or short URL", new_short_url_request_path %></li>
   <% end %>
   <% if current_user.can_manage_short_urls? %>
     <li class="list-group-item"><%= link_to "View pending requests", short_url_requests_path %></li>

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -8,16 +8,16 @@
     <div class="form-group">
       <%= f.label :from_path %>
       <%= f.text_field :from_path, disabled: @short_url_request.persisted?, class: 'form-control input-md-8' %>
-      <p class="help-block">This is the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").</p>
+      <p class="help-block">This is the URL or the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").</p>
     </div>
 
     <div class="form-group">
       <%= f.label :to_path %>
       <%= f.text_field :to_path, class: 'form-control input-md-8' %>
-      <p class="help-block">This is the path to redirect the user to. The following types of target URL are supported:</p>
+      <p class="help-block">This is the URL to redirect the user to. The following types of target URL are supported:</p>
       <ul class="help-block">
         <li>Internal gov.uk links, eg. <strong>/government/publications/what-hmrc-does-to-prevent-tax-evasion</strong></li>
-        <li>External gov.uk campaign links, eg. <strong>https://my-campaign-title.campaign.gov.uk/an-optional-path</strong></li>
+        <li>External gov.uk subdomain links, eg. <strong>https://my-title.external.gov.uk/an-optional-path</strong></li>
       </ul>
     </div>
 

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -3,7 +3,7 @@
     <dt>State:</dt>
     <dd><%= @short_url_request.state.titleize %></dd>
   </dl>
-  <%= render_errors_for @short_url_request, leading_message: "Your request for a short URL could not be made for the following reasons:" %>
+  <%= render_errors_for @short_url_request, leading_message: "Your request for a URL redirect or short URL could not be made for the following reasons:" %>
   <fieldset>
     <div class="form-group">
       <%= f.label :from_path %>

--- a/app/views/short_url_requests/_short_url_request_data.html.erb
+++ b/app/views/short_url_requests/_short_url_request_data.html.erb
@@ -6,7 +6,7 @@
   <dd><%= short_url_request.created_at.to_s(:govuk_date) %></dd>
 
   <% if show_short_url %>
-    <dt>Short URL:</dt>
+    <dt>URL redirect or short URL:</dt>
     <dd><%= short_url_request.from_path %></dd>
   <% end %>
 

--- a/app/views/short_url_requests/accept_failed.html.erb
+++ b/app/views/short_url_requests/accept_failed.html.erb
@@ -2,4 +2,4 @@
 
 <h1>The redirect could not be published</h1>
 
-<%= render_errors_for @short_url_request.redirect, leading_message: "The short URL could not be created for the following reasons:" %>
+<%= render_errors_for @short_url_request.redirect, leading_message: "The URL redirect or short URL could not be created for the following reasons:" %>

--- a/app/views/short_url_requests/confirmation.html.erb
+++ b/app/views/short_url_requests/confirmation.html.erb
@@ -5,11 +5,11 @@
   <%= f.hidden_field :reason %>
   <%= f.hidden_field :confirmed, value: true %>
   <% if would_overwrite_existing?(@short_url_request) %>
-    <h1>Redirects for that Short URL already exist!</h1>
+    <h1>Redirects for that URL redirect or short URL already exist!</h1>
   <% else %>
-    <h1>A short URL already redirects to that content</h1>
+    <h1>A URL redirect or short URL already redirects to that content</h1>
   <% end %>
-  <p>These short URLs are already live on GOV.UK:</p>
+  <p>These URL redirects or short URLs are already live on GOV.UK:</p>
   <ul>
     <% @short_url_request.similar_redirects.each do |dupe| %>
       <li>
@@ -22,10 +22,10 @@
     to <code><%= @short_url_request.to_path %>.</code>
   </p>
   <% if would_overwrite_existing?(@short_url_request) %>
-    <p>If your request is accepted, it will overwrite the existing short URL.</p>
+    <p>If your request is accepted, it will overwrite the existing URL redirect or short URL.</p>
   <% else %>
-    <p>Do you want another short URL to redirect to that content?</p>
+    <p>Do you want another URL redirect or short URL to redirect to that content?</p>
   <% end %>
-  <%= f.submit 'Yes, I still want to request this short URL', class: 'btn btn-success' %>
+  <%= f.submit 'Yes, I still want to request this URL redirect or short URL', class: 'btn btn-success' %>
   <%= link_to "Cancel", '/', class: "btn btn-default add-left-margin" %>
 <% end %>

--- a/app/views/short_url_requests/edit.html.erb
+++ b/app/views/short_url_requests/edit.html.erb
@@ -3,11 +3,10 @@
 <%= content_for :page_title, 'Edit short URL' %>
   <h1 class="page-title-with-border">
     <% if @short_url_request.pending? %>
-      Edit short URL request
+      Edit URL redirect or short URL request
     <% else %>
-      Edit live short URL
+      Edit live URL redirect or short URL
     <% end %>
   </h1>
 
   <%= render :partial => 'form' %>
-

--- a/app/views/short_url_requests/index.html.erb
+++ b/app/views/short_url_requests/index.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :short_url_requests %>
 
-<h1>Short URL requests</h1>
+<h1>URL redirect and short URL requests</h1>
 
 <%= will_paginate @short_url_requests %>
 <table class="table table-bordered table-hover">

--- a/app/views/short_url_requests/new.html.erb
+++ b/app/views/short_url_requests/new.html.erb
@@ -1,7 +1,7 @@
 <% breadcrumb :new_short_url_request %>
 
-<h1 class="page-title-with-border">Request a short URL</h1>
+<h1 class="page-title-with-border">Request a new URL redirect or short URL</h1>
 
-<p>If you are not familiar with requesting short URLs, please read <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">this guidance</a> first.</p>
+<p>Please read <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">the guidance on redirect requests</a> before making a request.</p>
 
 <%= render :partial => 'form' %>

--- a/app/views/short_url_requests/new_rejection.html.erb
+++ b/app/views/short_url_requests/new_rejection.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :reject_short_url_request, @short_url_request %>
 
-<h1>Reject this short URL request</h1>
+<h1>Reject this URL redirect or short URL request</h1>
 
 <%= render 'short_url_request_data', short_url_request: @short_url_request, show_short_url: true %>
 

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :short_url_request, @short_url_request %>
 
-<h1>Short URL requested by <%= @short_url_request.organisation_title %></h1>
+<h1>URL redirect or Short URL requested by <%= @short_url_request.organisation_title %></h1>
 
 <% if @short_url_request.state == 'pending' && @existing_redirect.present? %>
   <%= render 'existing_redirect', existing_redirect: @existing_redirect %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -3,17 +3,17 @@ crumb :root do
 end
 
 crumb :new_short_url_request do
-  link "Request a short URL", new_short_url_request_path
+  link "Request a new URL redirect or short URL", new_short_url_request_path
   parent :root
 end
 
 crumb :short_url_requests do
-  link "Short URL requests", short_url_requests_path
+  link "URL redirect or short URL requests", short_url_requests_path
   parent :root
 end
 
 crumb :live_short_urls do
-  link "Live short URLs", list_short_urls_path
+  link "Live URL redirects and short URLs", list_short_urls_path
   parent :root
 end
 
@@ -23,21 +23,21 @@ crumb :short_url_request do |short_url_request|
 end
 
 crumb :edit_short_url_request do |short_url_request|
-  link "Edit short URL", edit_short_url_request_path(short_url_request)
+  link "Edit URL redirect or short URL", edit_short_url_request_path(short_url_request)
   parent :short_url_request, short_url_request
 end
 
 crumb :reject_short_url_request do |short_url_request|
-  link "Reject short URL", reject_short_url_request_path(short_url_request)
+  link "Reject URL redirect or short URL", reject_short_url_request_path(short_url_request)
   parent :short_url_request, short_url_request
 end
 
 crumb :short_url_request_accepted do |short_url_request|
-  link "Short URL request accepted"
+  link "URL redirect or short URL request accepted"
   parent :short_url_request, short_url_request
 end
 
 crumb :short_url_request_accepted_failed do |short_url_request|
-  link "Short URL request accept failed"
+  link "URL redirect or short URL request accept failed"
   parent :short_url_request, short_url_request
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,6 @@ en:
   mongoid:
     attributes:
       short_url_request:
-        from_path: 'Short URL'
+        from_path: 'From or Short URL'
         to_path: 'Target URL'
         organisation_slug: 'Organisation'

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -10,7 +10,7 @@ feature "As a publisher, I can request a short URL" do
 
   scenario "Publisher requests a short_url, and short_url managers are notified" do
     visit "/"
-    click_on "Request a new short URL"
+    click_on "Request a new URL redirect or short URL"
 
     expect(page).to have_select "Organisation", selected: "Ministry of Magic"
 

--- a/spec/features/short_url_manager_views_accepted_requests_spec.rb
+++ b/spec/features/short_url_manager_views_accepted_requests_spec.rb
@@ -21,7 +21,7 @@ feature "Short URL manager views accepted short url requests" do
     end
 
     visit "/"
-    click_on "View live short URLs"
+    click_on "View live redirect URLs and short URLs"
 
     expect(page).to have_content "/ministry-of-beards"
     expect(page).to have_content "/government/organisations/ministry-of-beards"

--- a/spec/support/shared_examples_for_short_url_validations.rb
+++ b/spec/support/shared_examples_for_short_url_validations.rb
@@ -19,9 +19,9 @@ shared_examples_for "ShortUrlValidations" do |klass|
       expect(build(klass, to_path: '/a-path')).to be_valid
     end
 
-    it "may be a gov.uk campaign URL" do
-      expect(build(klass, to_path: 'https://my.campaign.gov.uk')).to be_valid
-      expect(build(klass, to_path: 'https://my.campaign.gov.uk/path')).to be_valid
+    it "may be a gov.uk subdomain URL" do
+      expect(build(klass, to_path: 'https://my.service.gov.uk')).to be_valid
+      expect(build(klass, to_path: 'https://my.service.gov.uk/path')).to be_valid
     end
 
     it "must be either a relative path or a gov.uk campaign URL" do


### PR DESCRIPTION
## Trello cards

* https://trello.com/c/ZG120ZYH/16-5-update-short-url-manager
* https://trello.com/c/jmxMgLWf/21-make-it-so-that-gds-content-designers-can-implement-redirects-reliably

## PRs this depends on

* https://github.com/alphagov/publishing-api/pull/874
* https://github.com/alphagov/publishing-api/pull/873
* https://github.com/alphagov/govuk-content-schemas/pull/605

Changes to the Publishing API and schemas are required in order to support this change.

## Motivation

This is part of work towards allowing content designers to create redirects without developer intervention or use of the router-data redirect system.

Broadens the definition that allows for “external” redirects from GOV.UK to the .campaign.gov.uk sub-domain to now allow redirects to any .gov.uk sub-domain.

The user interface changes are minimal tweaks in order to hit MVP in the short space of time we have left in our 2 week blitz. We will need to refactor further so that all mention of "short URL" in the code base becomes more generic. For example `@short_url_request` should be `@redirect_request`. And rename this repo perhaps.

## Expected changes

All mention of "Short URL" to now say "URL redirect and/or short URL".

### Before
![image](https://cloud.githubusercontent.com/assets/424772/24913774/18fc97fe-1eca-11e7-9052-3c1ce663f77a.png)

### After
![image](https://cloud.githubusercontent.com/assets/424772/24913783/246deab6-1eca-11e7-84e0-28b27d4f78cd.png)
