### PR TITLE
Add route type and segments mode

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -80,10 +80,10 @@ private
   end
 
   def create_short_url_request_params
-    params[:short_url_request].permit(:from_path, :to_path, :reason, :organisation_slug, :confirmed)
+    params[:short_url_request].permit(:from_path, :to_path, :reason, :route_type, :organisation_slug, :confirmed)
   end
 
   def update_short_url_request_params
-    params[:short_url_request].permit(:to_path, :reason, :organisation_slug)
+    params[:short_url_request].permit(:to_path, :reason, :route_type, :organisation_slug)
   end
 end

--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -80,10 +80,10 @@ private
   end
 
   def create_short_url_request_params
-    params[:short_url_request].permit(:from_path, :to_path, :reason, :route_type, :organisation_slug, :confirmed)
+    params[:short_url_request].permit(:from_path, :to_path, :reason, :route_type, :segments_mode, :organisation_slug, :confirmed)
   end
 
   def update_short_url_request_params
-    params[:short_url_request].permit(:to_path, :reason, :route_type, :organisation_slug)
+    params[:short_url_request].permit(:to_path, :reason, :route_type, :segments_mode, :organisation_slug)
   end
 end

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -9,6 +9,7 @@ class Redirect
   field :content_id, type: String
   field :from_path, type: String
   field :to_path, type: String
+  field :route_type, type: String
 
   belongs_to :short_url_request, required: false
 

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -9,8 +9,8 @@ class Redirect
   field :content_id, type: String
   field :from_path, type: String
   field :to_path, type: String
-  field :route_type, type: String
-  field :segments_mode, type: String
+  field :route_type, type: String, default: 'exact'
+  field :segments_mode, type: String, default: 'ignore'
 
   belongs_to :short_url_request, required: false
 

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -10,6 +10,7 @@ class Redirect
   field :from_path, type: String
   field :to_path, type: String
   field :route_type, type: String
+  field :segments_mode, type: String
 
   belongs_to :short_url_request, required: false
 

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -7,6 +7,7 @@ class ShortUrlRequest
   field :from_path, type: String
   field :to_path, type: String
   field :route_type, type: String, default: 'exact'
+  field :segments_mode, type: String, default: 'ignore'
   field :reason, type: String
   field :contact_email, type: String
   field :organisation_slug, type: String

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -6,6 +6,7 @@ class ShortUrlRequest
   field :state, type: String, default: 'pending'
   field :from_path, type: String
   field :to_path, type: String
+  field :route_type, type: String, default: 'exact'
   field :reason, type: String
   field :contact_email, type: String
   field :organisation_slug, type: String

--- a/app/presenters/publishing_api.rb
+++ b/app/presenters/publishing_api.rb
@@ -9,7 +9,7 @@ module Presenters
         "publishing_app" => "short-url-manager",
         "update_type" => "major",
         "redirects" => [
-          { "path" => redirect.from_path, "type" => redirect.route_type, "destination" => redirect.to_path }
+          { "path" => redirect.from_path, "type" => redirect.route_type, "segments_mode" => redirect.segments_mode, "destination" => redirect.to_path }
         ]
       }
     end

--- a/app/presenters/publishing_api.rb
+++ b/app/presenters/publishing_api.rb
@@ -9,7 +9,7 @@ module Presenters
         "publishing_app" => "short-url-manager",
         "update_type" => "major",
         "redirects" => [
-          { "path" => redirect.from_path, "type" => "exact", "destination" => redirect.to_path }
+          { "path" => redirect.from_path, "type" => redirect.route_type, "destination" => redirect.to_path }
         ]
       }
     end

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -27,6 +27,11 @@
     </div>
 
     <div class="form-group">
+      <%= f.label :segments_mode %>
+      <%= f.select :segments_mode, options_for_select(["ignore", "preserve"], @short_url_request.segments_mode), {}, class: 'form-control input-md-6' %>
+    </div>
+
+    <div class="form-group">
       <%= f.label :organisation_slug %>
       <%= f.select :organisation_slug, options_for_select(organisations.map {|org| [org.title, org.slug] }, @short_url_request.organisation_slug), {}, class: 'form-control input-md-6' %>
     </div>

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -22,6 +22,11 @@
     </div>
 
     <div class="form-group">
+      <%= f.label :route_type %>
+      <%= f.select :route_type, options_for_select(["exact", "prefix"], @short_url_request.route_type), {}, class: 'form-control input-md-6' %>
+    </div>
+
+    <div class="form-group">
       <%= f.label :organisation_slug %>
       <%= f.select :organisation_slug, options_for_select(organisations.map {|org| [org.title, org.slug] }, @short_url_request.organisation_slug), {}, class: 'form-control input-md-6' %>
     </div>

--- a/app/views/short_url_requests/_short_url_request_data.html.erb
+++ b/app/views/short_url_requests/_short_url_request_data.html.erb
@@ -13,6 +13,9 @@
   <dt>Target URL:</dt>
   <dd><%= link_to short_url_request.to_path, govuk_url_for(short_url_request.to_path) %></dd>
 
+  <dt>Route type:</dt>
+  <dd><%= short_url_request.route_type %></dd>
+
   <dt>Reason:</dt>
   <dd><%= short_url_request.reason %></dd>
 

--- a/app/views/short_url_requests/_short_url_request_data.html.erb
+++ b/app/views/short_url_requests/_short_url_request_data.html.erb
@@ -16,6 +16,9 @@
   <dt>Route type:</dt>
   <dd><%= short_url_request.route_type %></dd>
 
+  <dt>Segments mode:</dt>
+  <dd><%= short_url_request.segments_mode %></dd>
+
   <dt>Reason:</dt>
   <dd><%= short_url_request.reason %></dd>
 

--- a/lib/tasks/publishing_api_fields.rake
+++ b/lib/tasks/publishing_api_fields.rake
@@ -1,0 +1,11 @@
+namespace :publishing_api_fields do
+  desc "Set default value for route_type field for Redirects"
+  task set_default_route_type: :environment do
+    Redirect.where(route_type: nil).update_all(route_type: 'exact')
+  end
+
+  desc "Set default value for segments_mode field for Redirects"
+  task set_default_segments_mode: :environment do
+    Redirect.where(segments_mode: nil).update_all(segments_mode: 'ignore')
+  end
+end

--- a/spec/factories/redirect_factories.rb
+++ b/spec/factories/redirect_factories.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :redirect do
     sequence(:from_path) { |n| "/short-url-from-#{n}" }
     sequence(:to_path) { |n| "/short-url-to-#{n}" }
+    route_type "exact"
 
     trait(:invalid) {
       to_path nil

--- a/spec/factories/redirect_factories.rb
+++ b/spec/factories/redirect_factories.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     sequence(:from_path) { |n| "/short-url-from-#{n}" }
     sequence(:to_path) { |n| "/short-url-to-#{n}" }
     route_type "exact"
+    segments_mode "ignore"
 
     trait(:invalid) {
       to_path nil

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -17,6 +17,7 @@ feature "As a publisher, I can request a short URL" do
     fill_in "Short URL",          with: from_path = "/some-friendly-url"
     fill_in "Target URL",         with: to_path = "/government/publications/some-random-publication"
     select "exact",               from: "Route type"
+    select "ignore",              from: "Segments mode"
     select "Ministry of Beards",  from: "Organisation"
     fill_in "Reason",             with: reason = "Because of the wombats"
 

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -16,6 +16,7 @@ feature "As a publisher, I can request a short URL" do
 
     fill_in "Short URL",          with: from_path = "/some-friendly-url"
     fill_in "Target URL",         with: to_path = "/government/publications/some-random-publication"
+    select "exact",               from: "Route type"
     select "Ministry of Beards",  from: "Organisation"
     fill_in "Reason",             with: reason = "Because of the wombats"
 

--- a/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
@@ -23,6 +23,7 @@ feature "Short URL manager responds to short URL requests" do
   let!(:accepted_request) do
     create(:short_url_request, from_path: "/ministry-of-hair",
                                to_path: "/government/organisations/ministry-of-hair",
+                               route_type: "exact",
                                reason: "Hair enables beards to exist",
                                contact_email: "hairy@example.com",
                                created_at: Time.zone.parse("2014-01-01 12:00:00"),
@@ -90,7 +91,11 @@ feature "Short URL manager responds to short URL requests" do
     accepted_request.reload
     expect(accepted_request.organisation_slug).to eql("full-english")
     expect(accepted_request.organisation_title).to eql("Department of Full English Breakfasts")
-    assert_publishing_api_put_content(redirect_for_accepted_request.content_id, publishing_api_redirect_hash('/ministry-of-hair', target_url, accepted_request.redirect.content_id))
+    assert_publishing_api_put_content(redirect_for_accepted_request.content_id,
+                                      publishing_api_redirect_hash('/ministry-of-hair',
+                                                                   target_url,
+                                                                   accepted_request.redirect.content_id,
+                                                                   accepted_request.route_type))
     # publish has already been called once for the original redirect.
     assert_publishing_api_publish(redirect_for_accepted_request.content_id, nil, 2)
   end

--- a/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
@@ -24,6 +24,7 @@ feature "Short URL manager responds to short URL requests" do
     create(:short_url_request, from_path: "/ministry-of-hair",
                                to_path: "/government/organisations/ministry-of-hair",
                                route_type: "exact",
+                               segments_mode: "ignore",
                                reason: "Hair enables beards to exist",
                                contact_email: "hairy@example.com",
                                created_at: Time.zone.parse("2014-01-01 12:00:00"),
@@ -95,7 +96,8 @@ feature "Short URL manager responds to short URL requests" do
                                       publishing_api_redirect_hash('/ministry-of-hair',
                                                                    target_url,
                                                                    accepted_request.redirect.content_id,
-                                                                   accepted_request.route_type))
+                                                                   accepted_request.route_type,
+                                                                   accepted_request.segments_mode))
     # publish has already been called once for the original redirect.
     assert_publishing_api_publish(redirect_for_accepted_request.content_id, nil, 2)
   end

--- a/spec/features/short_url_manager_views_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_views_furl_requests_spec.rb
@@ -36,6 +36,7 @@ feature "Short URL manager finds information on short_url requests" do
   scenario "Short URL manager views the details for a single fRUL request" do
     create :short_url_request, from_path: "/ministry-of-beards",
                           to_path: "/government/organisations/ministry-of-beards",
+                          route_type: "exact",
                           reason: "Because we really need to think about beards",
                           contact_email: "gandalf@example.com",
                           created_at: Time.zone.parse("2014-01-01 12:00:00"),
@@ -49,6 +50,7 @@ feature "Short URL manager finds information on short_url requests" do
     expect(page).to have_content "12:00pm, 1 January 2014"
     expect(page).to have_content "/ministry-of-beards"
     expect(page).to have_link "/government/organisations/ministry-of-beards", href: "http://www.dev.gov.uk/government/organisations/ministry-of-beards"
+    expect(page).to have_content "exact"
     expect(page).to have_content "Because we really need to think about beards"
     expect(page).to have_content "gandalf@example.com"
   end

--- a/spec/features/short_url_manager_views_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_views_furl_requests_spec.rb
@@ -37,6 +37,7 @@ feature "Short URL manager finds information on short_url requests" do
     create :short_url_request, from_path: "/ministry-of-beards",
                           to_path: "/government/organisations/ministry-of-beards",
                           route_type: "exact",
+                          segments_mode: "preserve",
                           reason: "Because we really need to think about beards",
                           contact_email: "gandalf@example.com",
                           created_at: Time.zone.parse("2014-01-01 12:00:00"),
@@ -51,6 +52,7 @@ feature "Short URL manager finds information on short_url requests" do
     expect(page).to have_content "/ministry-of-beards"
     expect(page).to have_link "/government/organisations/ministry-of-beards", href: "http://www.dev.gov.uk/government/organisations/ministry-of-beards"
     expect(page).to have_content "exact"
+    expect(page).to have_content "preserve"
     expect(page).to have_content "Because we really need to think about beards"
     expect(page).to have_content "gandalf@example.com"
   end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -57,7 +57,7 @@ describe Redirect do
         let(:redirect) { build :redirect }
 
         it "should post a redirect content item to the publishing API" do
-          redirect_hash = publishing_api_redirect_hash(redirect.from_path, redirect.to_path, redirect.content_id)
+          redirect_hash = publishing_api_redirect_hash(redirect.from_path, redirect.to_path, redirect.content_id, redirect.route_type)
           assert_publishing_api_put_content(redirect.content_id, redirect_hash)
           assert_publishing_api_publish(redirect.content_id)
         end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -57,7 +57,7 @@ describe Redirect do
         let(:redirect) { build :redirect }
 
         it "should post a redirect content item to the publishing API" do
-          redirect_hash = publishing_api_redirect_hash(redirect.from_path, redirect.to_path, redirect.content_id, redirect.route_type)
+          redirect_hash = publishing_api_redirect_hash(redirect.from_path, redirect.to_path, redirect.content_id, redirect.route_type, redirect.segments_mode)
           assert_publishing_api_put_content(redirect.content_id, redirect_hash)
           assert_publishing_api_publish(redirect.content_id)
         end

--- a/spec/presenters/publishing_api_presenter_spec.rb
+++ b/spec/presenters/publishing_api_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Presenters::PublishingAPI do
       "publishing_app" => "short-url-manager",
       "update_type" => "major",
       "redirects" => [
-        { "path" => "/from/path", "type" => "exact", "destination" => "/to/path" }
+        { "path" => "/from/path", "type" => "exact", "segments_mode" => "ignore", "destination" => "/to/path" }
       ]
     )
   end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,5 +1,5 @@
 module PublishingApiHelper
-  def publishing_api_redirect_hash(from_path, to_path, content_id)
+  def publishing_api_redirect_hash(from_path, to_path, content_id, route_type)
     {
       "content_id" => content_id,
       "base_path" => from_path,
@@ -8,7 +8,7 @@ module PublishingApiHelper
       "publishing_app" => "short-url-manager",
       "update_type" => "major",
       "redirects" => [
-        { "path" => from_path, "type" => "exact", "destination" => to_path }
+        { "path" => from_path, "type" => route_type, "destination" => to_path }
       ]
     }
   end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,5 +1,5 @@
 module PublishingApiHelper
-  def publishing_api_redirect_hash(from_path, to_path, content_id, route_type)
+  def publishing_api_redirect_hash(from_path, to_path, content_id, route_type, segments_mode)
     {
       "content_id" => content_id,
       "base_path" => from_path,
@@ -8,7 +8,7 @@ module PublishingApiHelper
       "publishing_app" => "short-url-manager",
       "update_type" => "major",
       "redirects" => [
-        { "path" => from_path, "type" => route_type, "destination" => to_path }
+        { "path" => from_path, "type" => route_type, "segments_mode" => segments_mode, "destination" => to_path }
       ]
     }
   end


### PR DESCRIPTION
This is part of Content Tools team's 2 week blitz.

## Trello cards
* https://trello.com/c/XM9DuwVN
* https://trello.com/c/jmxMgLWf

Router data passes these fields to the publishing api. Short-URL-Manager will need to as well in order for us to support decommissioning of router-data.

Adds to the form for creating and updating redirects two new drop downs: `Route type` and `Segments mode`.

## Expected changes

## Before
![image](https://cloud.githubusercontent.com/assets/424772/25141413/66916210-245b-11e7-958b-01a24b29e38f.png)

## After
![image](https://cloud.githubusercontent.com/assets/424772/25141423/6c654828-245b-11e7-89c9-850cae9caa32.png)
