### PR TITLE
[DO NOT MERGE] Ui for advanced fields

### DIFF
--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -59,20 +59,18 @@
       <%= f.select :segments_mode, options_for_select({ "Discard" => "ignore", "Keep" => "preserve" }, @short_url_request.segments_mode), {}, class: 'form-control input-md-6' %>
     </div>
 
-    <dt>Discard</dt>
-    <dd>
-      <dt>...using "Exact URL only"</dt>
-      <dd>For source <strong>/from?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target</strong></dd>
-      <dt>...using "URL and all pages under it"</dt>
-      <dd>For source <strong>/from?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target</strong></dd>
-    </dd>
+    <h3>Help with Segments</h3>
+    <h4>Discard</h4>
+    <h5>Using "Exact URL only"</h5>
+    <p>For source <strong>/from?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target</strong></p>
+    <h5>Using "URL and all pages under it"</h5>
+    <p>For source <strong>/from?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target</strong></p>
 
-    <dt>Keep</dt>
-    <dd>
-      <dt>...using "Exact URL only"</dt>
-      <dd>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target?q=123</strong></dd>
-      <dt>...using "URL and all pages under it"</dt>
-      <dd>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target/page/?q=123</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target/doe/a/deer</strong></dd>
-    </dd>
+
+    <h4>Keep</h4>
+    <h5>Using "Exact URL only"</h5>
+    <p>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target?q=123</strong></p>
+    <h5>Using "URL and all pages under it"</h5>
+    <p>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target/page/?q=123</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target/doe/a/deer</strong></p>
   </fieldset>
 <%- end -%>

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -22,16 +22,6 @@
     </div>
 
     <div class="form-group">
-      <%= f.label :route_type %>
-      <%= f.select :route_type, options_for_select(["exact", "prefix"], @short_url_request.route_type), {}, class: 'form-control input-md-6' %>
-    </div>
-
-    <div class="form-group">
-      <%= f.label :segments_mode %>
-      <%= f.select :segments_mode, options_for_select(["ignore", "preserve"], @short_url_request.segments_mode), {}, class: 'form-control input-md-6' %>
-    </div>
-
-    <div class="form-group">
       <%= f.label :organisation_slug %>
       <%= f.select :organisation_slug, options_for_select(organisations.map {|org| [org.title, org.slug] }, @short_url_request.organisation_slug), {}, class: 'form-control input-md-6' %>
     </div>
@@ -52,6 +42,21 @@
         <%= f.submit "Update", class: 'btn btn-success' %>
         <%= link_to "Cancel", short_url_request_path(@short_url_request), class: "btn btn-default add-left-margin" %>
       <% end %>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <h2>Advanced options</h2>
+    <p>Leave as defaults if unsure.</p>
+    <div class="form-group">
+      <%= f.label 'From redirects' %>
+      <%= f.select :route_type, options_for_select({"Exact URL only" => "exact", "URL and all pages under it" => "prefix"}, @short_url_request.route_type), {}, class: 'form-control input-md-6' %>
+      <p>Do not redirect all pages unless you need any page with an address which starts with your input to also be redirected. For example, if you add <strong>gov.uk/address/</strong> then <strong>gov.uk/address/gone</strong> would also be redirected.</p>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :segments_mode %>
+      <%= f.select :segments_mode, options_for_select(["ignore", "preserve"], @short_url_request.segments_mode), {}, class: 'form-control input-md-6' %>
     </div>
   </fieldset>
 <%- end -%>

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -50,13 +50,29 @@
     <p>Leave as defaults if unsure.</p>
     <div class="form-group">
       <%= f.label 'From redirects' %>
-      <%= f.select :route_type, options_for_select({"Exact URL only" => "exact", "URL and all pages under it" => "prefix"}, @short_url_request.route_type), {}, class: 'form-control input-md-6' %>
+      <%= f.select :route_type, options_for_select({ "Exact URL only" => "exact", "URL and all pages under it" => "prefix" }, @short_url_request.route_type), {}, class: 'form-control input-md-6' %>
       <p>Do not redirect all pages unless you need any page with an address which starts with your input to also be redirected. For example, if you add <strong>gov.uk/address/</strong> then <strong>gov.uk/address/gone</strong> would also be redirected.</p>
     </div>
 
     <div class="form-group">
-      <%= f.label :segments_mode %>
-      <%= f.select :segments_mode, options_for_select(["ignore", "preserve"], @short_url_request.segments_mode), {}, class: 'form-control input-md-6' %>
+      <%= f.label 'Segments' %>
+      <%= f.select :segments_mode, options_for_select({ "Discard" => "ignore", "Keep" => "preserve" }, @short_url_request.segments_mode), {}, class: 'form-control input-md-6' %>
     </div>
+
+    <dt>Discard</dt>
+    <dd>
+      <dt>...using "Exact URL only"</dt>
+      <dd>For source <strong>/from?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target</strong></dd>
+      <dt>...using "URL and all pages under it"</dt>
+      <dd>For source <strong>/from?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target</strong></dd>
+    </dd>
+
+    <dt>Keep</dt>
+    <dd>
+      <dt>...using "Exact URL only"</dt>
+      <dd>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target?q=123</strong></dd>
+      <dt>...using "URL and all pages under it"</dt>
+      <dd>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target/page/?q=123</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target/doe/a/deer</strong></dd>
+    </dd>
   </fieldset>
 <%- end -%>

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -17,7 +17,7 @@ feature "As a publisher, I can request a short URL" do
     fill_in "From or short URL",  with: from_path = "/some-friendly-url"
     fill_in "Target URL",         with: to_path = "/government/publications/some-random-publication"
     select "Exact URL only",      from: "short_url_request_route_type"
-    select "ignore",              from: "Segments mode"
+    select "Discard",             from: "short_url_request_segments_mode"
     select "Ministry of Beards",  from: "Organisation"
     fill_in "Reason",             with: reason = "Because of the wombats"
 

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -16,7 +16,7 @@ feature "As a publisher, I can request a short URL" do
 
     fill_in "From or short URL",  with: from_path = "/some-friendly-url"
     fill_in "Target URL",         with: to_path = "/government/publications/some-random-publication"
-    select "exact",               from: "Route type"
+    select "Exact URL only",      from: "short_url_request_route_type"
     select "ignore",              from: "Segments mode"
     select "Ministry of Beards",  from: "Organisation"
     fill_in "Reason",             with: reason = "Because of the wombats"


### PR DESCRIPTION
[Trello card](https://trello.com/c/dpv7ax9L/48-2-amend-ui-and-copy-for-route-type-and-segments-mode)

Add help text on what the `route_type` and `segments_mode` fields do. Amend form so that these are displayed as advanced options.

## Before
![image](https://cloud.githubusercontent.com/assets/424772/25189580/78fced2c-2521-11e7-9565-4dbca3f300f9.png)

## After
![image](https://cloud.githubusercontent.com/assets/424772/25189603/81f6cac4-2521-11e7-90bb-030185457590.png)
