### PR TITLE
Revert reversion of blitz changes

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -37,6 +37,10 @@ class ShortUrlRequestsController < ApplicationController
   end
 
   def accept
+    if @short_url_request.uses_advanced_options?
+      authorise_user!('advanced_options')
+    end
+
     Commands::ShortUrlRequests::Accept.new(@short_url_request).call(
       failure: -> () { render 'short_url_requests/accept_failed' }
     )
@@ -70,6 +74,18 @@ class ShortUrlRequestsController < ApplicationController
     @organisations ||= Organisation.all.order_by([:title, 'asc'])
   end
   helper_method :organisations
+
+  def allow_use_of_advanced_options?
+    current_user.has_permission? 'advanced_options'
+  end
+  helper_method :allow_use_of_advanced_options?
+
+  def allow_accepting_request?
+    return true unless @short_url_request.uses_advanced_options?
+
+    allow_use_of_advanced_options?
+  end
+  helper_method :allow_accepting_request?
 
 private
 

--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -80,10 +80,10 @@ private
   end
 
   def create_short_url_request_params
-    params[:short_url_request].permit(:from_path, :to_path, :reason, :organisation_slug, :confirmed)
+    params[:short_url_request].permit(:from_path, :to_path, :reason, :route_type, :segments_mode, :organisation_slug, :confirmed)
   end
 
   def update_short_url_request_params
-    params[:short_url_request].permit(:to_path, :reason, :organisation_slug)
+    params[:short_url_request].permit(:to_path, :reason, :route_type, :segments_mode, :organisation_slug)
   end
 end

--- a/app/models/concerns/short_url_validations.rb
+++ b/app/models/concerns/short_url_validations.rb
@@ -8,14 +8,14 @@ module ShortUrlValidations
   end
 
   def to_path_is_valid
-    unless to_path.blank? || to_path =~ /\A\// || govuk_campaign_url?(to_path)
-      errors.add(:to_path, 'must be a relative path (eg. "/hmrc/tax-returns") or a gov.uk campaign URL (eg. "https://my-campaign-title.campaign.gov.uk/an-optional-path")')
+    unless to_path.blank? || to_path =~ /\A\// || govuk_subdomain_url?(to_path)
+      errors.add(:to_path, 'must be a relative path (eg. "/hmrc/tax-returns") or a gov.uk redirect URL (eg. "https://my-title.service.gov.uk/an-optional-path")')
     end
   end
 
-  def govuk_campaign_url?(path)
+  def govuk_subdomain_url?(path)
     uri = URI.parse(path)
-    uri.host =~ /\A.+\.campaign\.gov\.uk\z/i && uri.scheme == 'https'
+    uri.host =~ /\A([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\.)*gov\.uk\z/i && uri.scheme == 'https'
   rescue
     false
   end

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -9,6 +9,8 @@ class Redirect
   field :content_id, type: String
   field :from_path, type: String
   field :to_path, type: String
+  field :route_type, type: String, default: 'exact'
+  field :segments_mode, type: String, default: 'ignore'
 
   belongs_to :short_url_request, required: false
 

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -53,6 +53,10 @@ class ShortUrlRequest
     state == 'superseded'
   end
 
+  def uses_advanced_options?
+    route_type != 'exact' || segments_mode != 'ignore'
+  end
+
 private
 
   def not_already_live

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -6,6 +6,8 @@ class ShortUrlRequest
   field :state, type: String, default: 'pending'
   field :from_path, type: String
   field :to_path, type: String
+  field :route_type, type: String, default: 'exact'
+  field :segments_mode, type: String, default: 'ignore'
   field :reason, type: String
   field :contact_email, type: String
   field :organisation_slug, type: String

--- a/app/presenters/publishing_api.rb
+++ b/app/presenters/publishing_api.rb
@@ -9,7 +9,7 @@ module Presenters
         "publishing_app" => "short-url-manager",
         "update_type" => "major",
         "redirects" => [
-          { "path" => redirect.from_path, "type" => "exact", "destination" => redirect.to_path }
+          { "path" => redirect.from_path, "type" => redirect.route_type, "segments_mode" => redirect.segments_mode, "destination" => redirect.to_path }
         ]
       }
     end

--- a/app/views/dashboard/dashboard.html.erb
+++ b/app/views/dashboard/dashboard.html.erb
@@ -4,10 +4,10 @@
 
 <ul class="list-group col-md-6">
   <% if current_user.can_request_short_urls? %>
-    <li class="list-group-item"><%= link_to "Request a new short URL", new_short_url_request_path %></li>
+    <li class="list-group-item"><%= link_to "Request a new URL redirect or short URL", new_short_url_request_path %></li>
   <% end %>
   <% if current_user.can_manage_short_urls? %>
     <li class="list-group-item"><%= link_to "View pending requests", short_url_requests_path %></li>
-    <li class="list-group-item"><%= link_to "View live short URLs", list_short_urls_path %></li>
+    <li class="list-group-item"><%= link_to "View live URL redirects and short URLs", list_short_urls_path %></li>
   <% end %>
 </ul>

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -45,6 +45,7 @@
     </div>
   </fieldset>
 
+  <% if allow_use_of_advanced_options? %>
   <fieldset>
     <h2>Advanced options</h2>
     <p>Leave as defaults if unsure.</p>
@@ -73,4 +74,5 @@
     <h5>Using "URL and all pages under it"</h5>
     <p>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target/page/?q=123</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target/doe/a/deer</strong></p>
   </fieldset>
+  <% end %>
 <%- end -%>

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -3,22 +3,32 @@
     <dt>State:</dt>
     <dd><%= @short_url_request.state.titleize %></dd>
   </dl>
-  <%= render_errors_for @short_url_request, leading_message: "Your request for a short URL could not be made for the following reasons:" %>
+  <%= render_errors_for @short_url_request, leading_message: "Your request for a URL redirect or short URL could not be made for the following reasons:" %>
   <fieldset>
     <div class="form-group">
       <%= f.label :from_path %>
       <%= f.text_field :from_path, disabled: @short_url_request.persisted?, class: 'form-control input-md-8' %>
-      <p class="help-block">This is the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").</p>
+      <p class="help-block">This is the URL or the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").</p>
     </div>
 
     <div class="form-group">
       <%= f.label :to_path %>
       <%= f.text_field :to_path, class: 'form-control input-md-8' %>
-      <p class="help-block">This is the path to redirect the user to. The following types of target URL are supported:</p>
+      <p class="help-block">This is the URL to redirect the user to. The following types of target URL are supported:</p>
       <ul class="help-block">
         <li>Internal gov.uk links, eg. <strong>/government/publications/what-hmrc-does-to-prevent-tax-evasion</strong></li>
-        <li>External gov.uk campaign links, eg. <strong>https://my-campaign-title.campaign.gov.uk/an-optional-path</strong></li>
+        <li>External gov.uk subdomain links, eg. <strong>https://my-title.external.gov.uk/an-optional-path</strong></li>
       </ul>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :route_type %>
+      <%= f.select :route_type, options_for_select(["exact", "prefix"], @short_url_request.route_type), {}, class: 'form-control input-md-6' %>
+    </div>
+
+    <div class="form-group">
+      <%= f.label :segments_mode %>
+      <%= f.select :segments_mode, options_for_select(["ignore", "preserve"], @short_url_request.segments_mode), {}, class: 'form-control input-md-6' %>
     </div>
 
     <div class="form-group">
@@ -29,7 +39,7 @@
     <div class="form-group">
       <%= f.label :reason %>
       <%= f.text_area :reason, class: 'form-control input-md-8' %>
-      <p class="help-block">Please explain the reason for this request, as requests without a clear and valid reason will be denied. Please also include any other information relevant to this request such as Zendesk ticket numbers.</p>
+      <p class="help-block">Please explain the reason for this request, as requests without a clear and valid reason will be denied. Include any Zendesk ticket URL or other information if available.</p>
     </div>
   </fieldset>
 

--- a/app/views/short_url_requests/_short_url_request_data.html.erb
+++ b/app/views/short_url_requests/_short_url_request_data.html.erb
@@ -6,12 +6,18 @@
   <dd><%= short_url_request.created_at.to_s(:govuk_date) %></dd>
 
   <% if show_short_url %>
-    <dt>Short URL:</dt>
+    <dt>URL redirect or short URL:</dt>
     <dd><%= short_url_request.from_path %></dd>
   <% end %>
 
   <dt>Target URL:</dt>
   <dd><%= link_to short_url_request.to_path, govuk_url_for(short_url_request.to_path) %></dd>
+
+  <dt>Route type:</dt>
+  <dd><%= short_url_request.route_type %></dd>
+
+  <dt>Segments mode:</dt>
+  <dd><%= short_url_request.segments_mode %></dd>
 
   <dt>Reason:</dt>
   <dd><%= short_url_request.reason %></dd>

--- a/app/views/short_url_requests/accept_failed.html.erb
+++ b/app/views/short_url_requests/accept_failed.html.erb
@@ -2,4 +2,4 @@
 
 <h1>The redirect could not be published</h1>
 
-<%= render_errors_for @short_url_request.redirect, leading_message: "The short URL could not be created for the following reasons:" %>
+<%= render_errors_for @short_url_request.redirect, leading_message: "The URL redirect or short URL could not be created for the following reasons:" %>

--- a/app/views/short_url_requests/confirmation.html.erb
+++ b/app/views/short_url_requests/confirmation.html.erb
@@ -5,11 +5,11 @@
   <%= f.hidden_field :reason %>
   <%= f.hidden_field :confirmed, value: true %>
   <% if would_overwrite_existing?(@short_url_request) %>
-    <h1>Redirects for that Short URL already exist!</h1>
+    <h1>Redirects for that URL redirect or short URL already exist!</h1>
   <% else %>
-    <h1>A short URL already redirects to that content</h1>
+    <h1>A URL redirect or short URL already redirects to that content</h1>
   <% end %>
-  <p>These short URLs are already live on GOV.UK:</p>
+  <p>These URL redirects or short URLs are already live on GOV.UK:</p>
   <ul>
     <% @short_url_request.similar_redirects.each do |dupe| %>
       <li>
@@ -22,10 +22,10 @@
     to <code><%= @short_url_request.to_path %>.</code>
   </p>
   <% if would_overwrite_existing?(@short_url_request) %>
-    <p>If your request is accepted, it will overwrite the existing short URL.</p>
+    <p>If your request is accepted, it will overwrite the existing URL redirect or short URL.</p>
   <% else %>
-    <p>Do you want another short URL to redirect to that content?</p>
+    <p>Do you want another URL redirect or short URL to redirect to that content?</p>
   <% end %>
-  <%= f.submit 'Yes, I still want to request this short URL', class: 'btn btn-success' %>
+  <%= f.submit 'Yes, I still want to request this URL redirect or short URL', class: 'btn btn-success' %>
   <%= link_to "Cancel", '/', class: "btn btn-default add-left-margin" %>
 <% end %>

--- a/app/views/short_url_requests/edit.html.erb
+++ b/app/views/short_url_requests/edit.html.erb
@@ -3,11 +3,10 @@
 <%= content_for :page_title, 'Edit short URL' %>
   <h1 class="page-title-with-border">
     <% if @short_url_request.pending? %>
-      Edit short URL request
+      Edit URL redirect or short URL request
     <% else %>
-      Edit live short URL
+      Edit live URL redirect or short URL
     <% end %>
   </h1>
 
   <%= render :partial => 'form' %>
-

--- a/app/views/short_url_requests/index.html.erb
+++ b/app/views/short_url_requests/index.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :short_url_requests %>
 
-<h1>Short URL requests</h1>
+<h1>URL redirect and short URL requests</h1>
 
 <%= will_paginate @short_url_requests %>
 <table class="table table-bordered table-hover">

--- a/app/views/short_url_requests/new.html.erb
+++ b/app/views/short_url_requests/new.html.erb
@@ -1,7 +1,7 @@
 <% breadcrumb :new_short_url_request %>
 
-<h1 class="page-title-with-border">Request a short URL</h1>
+<h1 class="page-title-with-border">Request a new URL redirect or short URL</h1>
 
-<p>If you are not familiar with requesting short URLs, please read <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">this guidance</a> first.</p>
+<p>Please read <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/request-a-thing#short-url">the guidance on short URL requests</a> before making a request.</p>
 
 <%= render :partial => 'form' %>

--- a/app/views/short_url_requests/new_rejection.html.erb
+++ b/app/views/short_url_requests/new_rejection.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :reject_short_url_request, @short_url_request %>
 
-<h1>Reject this short URL request</h1>
+<h1>Reject this URL redirect or short URL request</h1>
 
 <%= render 'short_url_request_data', short_url_request: @short_url_request, show_short_url: true %>
 

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -25,8 +25,21 @@
   </div>
 </div>
 
+<% unless allow_accepting_request? %>
+  <div class="panel panel-danger">
+    <div class="panel-heading">
+      <h2>You cannot accept this redirect request at the moment</h2>
+    </div>
+    <div class="panel-body">
+      Accepting redirect requests with a type of 'prefix', or a
+      segments mode of 'ignore' is currently disabled for most users,
+      as this functionality is still being developed.
+    </div>
+  </div>
+<% end %>
+
 <% if @short_url_request.state == 'pending' %>
-  <%= button_to "Accept and create redirect", accept_short_url_request_path(@short_url_request), method: :post, class: "btn btn-success add-right-margin" %>
+  <%= button_to "Accept and create redirect", accept_short_url_request_path(@short_url_request), method: :post, class: "btn btn-success add-right-margin", disabled: allow_accepting_request? ? nil : 'disabled' %>
   <%= link_to "Reject", new_rejection_short_url_request_path(@short_url_request), class: "btn btn-danger add-right-margin" %>
 <% end %>
 <%= link_to "Edit", edit_short_url_request_path, class: "btn btn-default" %>

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :short_url_request, @short_url_request %>
 
-<h1>Short URL requested by <%= @short_url_request.organisation_title %></h1>
+<h1>URL redirect or Short URL requested by <%= @short_url_request.organisation_title %></h1>
 
 <% if @short_url_request.state == 'pending' && @existing_redirect.present? %>
   <%= render 'existing_redirect', existing_redirect: @existing_redirect %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -3,17 +3,17 @@ crumb :root do
 end
 
 crumb :new_short_url_request do
-  link "Request a short URL", new_short_url_request_path
+  link "Request a new URL redirect or short URL", new_short_url_request_path
   parent :root
 end
 
 crumb :short_url_requests do
-  link "Short URL requests", short_url_requests_path
+  link "URL redirect or short URL requests", short_url_requests_path
   parent :root
 end
 
 crumb :live_short_urls do
-  link "Live short URLs", list_short_urls_path
+  link "Live URL redirects and short URLs", list_short_urls_path
   parent :root
 end
 
@@ -23,21 +23,21 @@ crumb :short_url_request do |short_url_request|
 end
 
 crumb :edit_short_url_request do |short_url_request|
-  link "Edit short URL", edit_short_url_request_path(short_url_request)
+  link "Edit URL redirect or short URL", edit_short_url_request_path(short_url_request)
   parent :short_url_request, short_url_request
 end
 
 crumb :reject_short_url_request do |short_url_request|
-  link "Reject short URL", reject_short_url_request_path(short_url_request)
+  link "Reject URL redirect or short URL", reject_short_url_request_path(short_url_request)
   parent :short_url_request, short_url_request
 end
 
 crumb :short_url_request_accepted do |short_url_request|
-  link "Short URL request accepted"
+  link "URL redirect or short URL request accepted"
   parent :short_url_request, short_url_request
 end
 
 crumb :short_url_request_accepted_failed do |short_url_request|
-  link "Short URL request accept failed"
+  link "URL redirect or short URL request accept failed"
   parent :short_url_request, short_url_request
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,6 @@ en:
   mongoid:
     attributes:
       short_url_request:
-        from_path: 'Short URL'
+        from_path: 'From or short URL'
         to_path: 'Target URL'
         organisation_slug: 'Organisation'

--- a/lib/tasks/publishing_api_fields.rake
+++ b/lib/tasks/publishing_api_fields.rake
@@ -1,0 +1,11 @@
+namespace :publishing_api_fields do
+  desc "Set default value for route_type field for Redirects"
+  task set_default_route_type: :environment do
+    Redirect.where(route_type: nil).update_all(route_type: 'exact')
+  end
+
+  desc "Set default value for segments_mode field for Redirects"
+  task set_default_segments_mode: :environment do
+    Redirect.where(segments_mode: nil).update_all(segments_mode: 'ignore')
+  end
+end

--- a/spec/factories/redirect_factories.rb
+++ b/spec/factories/redirect_factories.rb
@@ -2,6 +2,8 @@ FactoryGirl.define do
   factory :redirect do
     sequence(:from_path) { |n| "/short-url-from-#{n}" }
     sequence(:to_path) { |n| "/short-url-to-#{n}" }
+    route_type "exact"
+    segments_mode "ignore"
 
     trait(:invalid) {
       to_path nil

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -10,12 +10,14 @@ feature "As a publisher, I can request a short URL" do
 
   scenario "Publisher requests a short_url, and short_url managers are notified" do
     visit "/"
-    click_on "Request a new short URL"
+    click_on "Request a new URL redirect or short URL"
 
     expect(page).to have_select "Organisation", selected: "Ministry of Magic"
 
-    fill_in "Short URL",          with: from_path = "/some-friendly-url"
+    fill_in "From or short URL",  with: from_path = "/some-friendly-url"
     fill_in "Target URL",         with: to_path = "/government/publications/some-random-publication"
+    select "exact",               from: "Route type"
+    select "ignore",              from: "Segments mode"
     select "Ministry of Beards",  from: "Organisation"
     fill_in "Reason",             with: reason = "Because of the wombats"
 

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -13,6 +13,7 @@ feature "As a publisher, I can request a short URL" do
     click_on "Request a new URL redirect or short URL"
 
     expect(page).to have_select "Organisation", selected: "Ministry of Magic"
+    expect(page).to have_no_content "Advanced options"
 
     fill_in "From or short URL",  with: from_path = "/some-friendly-url"
     fill_in "Target URL",         with: to_path = "/government/publications/some-random-publication"

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -16,8 +16,6 @@ feature "As a publisher, I can request a short URL" do
 
     fill_in "From or short URL",  with: from_path = "/some-friendly-url"
     fill_in "Target URL",         with: to_path = "/government/publications/some-random-publication"
-    select "Exact URL only",      from: "short_url_request_route_type"
-    select "Discard",             from: "short_url_request_segments_mode"
     select "Ministry of Beards",  from: "Organisation"
     fill_in "Reason",             with: reason = "Because of the wombats"
 

--- a/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
@@ -23,6 +23,8 @@ feature "Short URL manager responds to short URL requests" do
   let!(:accepted_request) do
     create(:short_url_request, from_path: "/ministry-of-hair",
                                to_path: "/government/organisations/ministry-of-hair",
+                               route_type: "exact",
+                               segments_mode: "ignore",
                                reason: "Hair enables beards to exist",
                                contact_email: "hairy@example.com",
                                created_at: Time.zone.parse("2014-01-01 12:00:00"),
@@ -90,7 +92,12 @@ feature "Short URL manager responds to short URL requests" do
     accepted_request.reload
     expect(accepted_request.organisation_slug).to eql("full-english")
     expect(accepted_request.organisation_title).to eql("Department of Full English Breakfasts")
-    assert_publishing_api_put_content(redirect_for_accepted_request.content_id, publishing_api_redirect_hash('/ministry-of-hair', target_url, accepted_request.redirect.content_id))
+    assert_publishing_api_put_content(redirect_for_accepted_request.content_id,
+                                      publishing_api_redirect_hash('/ministry-of-hair',
+                                                                   target_url,
+                                                                   accepted_request.redirect.content_id,
+                                                                   accepted_request.route_type,
+                                                                   accepted_request.segments_mode))
     # publish has already been called once for the original redirect.
     assert_publishing_api_publish(redirect_for_accepted_request.content_id, nil, 2)
   end

--- a/spec/features/short_url_manager_views_accepted_requests_spec.rb
+++ b/spec/features/short_url_manager_views_accepted_requests_spec.rb
@@ -21,7 +21,7 @@ feature "Short URL manager views accepted short url requests" do
     end
 
     visit "/"
-    click_on "View live short URLs"
+    click_on "View live URL redirects and short URLs"
 
     expect(page).to have_content "/ministry-of-beards"
     expect(page).to have_content "/government/organisations/ministry-of-beards"

--- a/spec/features/short_url_manager_views_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_views_furl_requests_spec.rb
@@ -36,6 +36,8 @@ feature "Short URL manager finds information on short_url requests" do
   scenario "Short URL manager views the details for a single fRUL request" do
     create :short_url_request, from_path: "/ministry-of-beards",
                           to_path: "/government/organisations/ministry-of-beards",
+                          route_type: "exact",
+                          segments_mode: "preserve",
                           reason: "Because we really need to think about beards",
                           contact_email: "gandalf@example.com",
                           created_at: Time.zone.parse("2014-01-01 12:00:00"),
@@ -49,6 +51,8 @@ feature "Short URL manager finds information on short_url requests" do
     expect(page).to have_content "12:00pm, 1 January 2014"
     expect(page).to have_content "/ministry-of-beards"
     expect(page).to have_link "/government/organisations/ministry-of-beards", href: "http://www.dev.gov.uk/government/organisations/ministry-of-beards"
+    expect(page).to have_content "exact"
+    expect(page).to have_content "preserve"
     expect(page).to have_content "Because we really need to think about beards"
     expect(page).to have_content "gandalf@example.com"
   end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -57,7 +57,7 @@ describe Redirect do
         let(:redirect) { build :redirect }
 
         it "should post a redirect content item to the publishing API" do
-          redirect_hash = publishing_api_redirect_hash(redirect.from_path, redirect.to_path, redirect.content_id)
+          redirect_hash = publishing_api_redirect_hash(redirect.from_path, redirect.to_path, redirect.content_id, redirect.route_type, redirect.segments_mode)
           assert_publishing_api_put_content(redirect.content_id, redirect_hash)
           assert_publishing_api_publish(redirect.content_id)
         end

--- a/spec/presenters/publishing_api_presenter_spec.rb
+++ b/spec/presenters/publishing_api_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Presenters::PublishingAPI do
       "publishing_app" => "short-url-manager",
       "update_type" => "major",
       "redirects" => [
-        { "path" => "/from/path", "type" => "exact", "destination" => "/to/path" }
+        { "path" => "/from/path", "type" => "exact", "segments_mode" => "ignore", "destination" => "/to/path" }
       ]
     )
   end

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,5 +1,5 @@
 module PublishingApiHelper
-  def publishing_api_redirect_hash(from_path, to_path, content_id)
+  def publishing_api_redirect_hash(from_path, to_path, content_id, route_type, segments_mode)
     {
       "content_id" => content_id,
       "base_path" => from_path,
@@ -8,7 +8,7 @@ module PublishingApiHelper
       "publishing_app" => "short-url-manager",
       "update_type" => "major",
       "redirects" => [
-        { "path" => from_path, "type" => "exact", "destination" => to_path }
+        { "path" => from_path, "type" => route_type, "segments_mode" => segments_mode, "destination" => to_path }
       ]
     }
   end

--- a/spec/support/shared_examples_for_short_url_validations.rb
+++ b/spec/support/shared_examples_for_short_url_validations.rb
@@ -19,9 +19,9 @@ shared_examples_for "ShortUrlValidations" do |klass|
       expect(build(klass, to_path: '/a-path')).to be_valid
     end
 
-    it "may be a gov.uk campaign URL" do
-      expect(build(klass, to_path: 'https://my.campaign.gov.uk')).to be_valid
-      expect(build(klass, to_path: 'https://my.campaign.gov.uk/path')).to be_valid
+    it "may be a gov.uk subdomain URL" do
+      expect(build(klass, to_path: 'https://my.service.gov.uk')).to be_valid
+      expect(build(klass, to_path: 'https://my.service.gov.uk/path')).to be_valid
     end
 
     it "must be either a relative path or a gov.uk campaign URL" do


### PR DESCRIPTION
This includes the changes that were done in the blitz (2017), both those that were reverted after being merged in to master, and some unmerged changes.

To avoid any issues relating to the interface, an additional change has been added that restricts using the new functionality to users with a `advanced_options` permission, both in terms of making requests, and approving requests.