### PR TITLE
Don't present content_id as part of the payload

### DIFF
--- a/app/presenters/publishing_api.rb
+++ b/app/presenters/publishing_api.rb
@@ -2,15 +2,19 @@ module Presenters
   module PublishingAPI
     def self.present(redirect)
       {
-        "content_id" => redirect.content_id,
         "base_path" => redirect.from_path,
         "document_type" => "redirect",
         "schema_name" => "redirect",
         "publishing_app" => "short-url-manager",
         "update_type" => "major",
         "redirects" => [
-          { "path" => redirect.from_path, "type" => redirect.route_type, "segments_mode" => redirect.segments_mode, "destination" => redirect.to_path }
-        ]
+          {
+            "path" => redirect.from_path,
+            "type" => redirect.route_type,
+            "segments_mode" => redirect.segments_mode,
+            "destination" => redirect.to_path,
+          },
+        ],
       }
     end
   end

--- a/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
@@ -95,7 +95,6 @@ feature "Short URL manager responds to short URL requests" do
     assert_publishing_api_put_content(redirect_for_accepted_request.content_id,
                                       publishing_api_redirect_hash('/ministry-of-hair',
                                                                    target_url,
-                                                                   accepted_request.redirect.content_id,
                                                                    accepted_request.route_type,
                                                                    accepted_request.segments_mode))
     # publish has already been called once for the original redirect.

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -57,7 +57,7 @@ describe Redirect do
         let(:redirect) { build :redirect }
 
         it "should post a redirect content item to the publishing API" do
-          redirect_hash = publishing_api_redirect_hash(redirect.from_path, redirect.to_path, redirect.content_id, redirect.route_type, redirect.segments_mode)
+          redirect_hash = publishing_api_redirect_hash(redirect.from_path, redirect.to_path, redirect.route_type, redirect.segments_mode)
           assert_publishing_api_put_content(redirect.content_id, redirect_hash)
           assert_publishing_api_publish(redirect.content_id)
         end

--- a/spec/presenters/publishing_api_presenter_spec.rb
+++ b/spec/presenters/publishing_api_presenter_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Presenters::PublishingAPI do
     presented = described_class.present(redirect)
 
     expect(presented).to eq(
-      "content_id" => redirect.content_id,
       "base_path" => "/from/path",
       "schema_name" => "redirect",
       "document_type" => "redirect",

--- a/spec/support/publishing_api_helper.rb
+++ b/spec/support/publishing_api_helper.rb
@@ -1,7 +1,6 @@
 module PublishingApiHelper
-  def publishing_api_redirect_hash(from_path, to_path, content_id, route_type, segments_mode)
+  def publishing_api_redirect_hash(from_path, to_path, route_type, segments_mode)
     {
-      "content_id" => content_id,
       "base_path" => from_path,
       "document_type" => "redirect",
       "schema_name" => "redirect",


### PR DESCRIPTION
Instead the `content_id` is passed as part of the endpoint path, and this value inside the hash won't be used.