### PR TITLE
Enable updating redirects in redirects:import

### DIFF
--- a/lib/tasks/import_redirects.rake
+++ b/lib/tasks/import_redirects.rake
@@ -3,14 +3,18 @@ require 'gds_api/publishing_api'
 
 namespace :redirects do
   desc "Import redirects"
-  task :import, [:file, :change_path_reservation?] => :environment do |_, args|
-    args.with_defaults(change_path_reservation?: false)
+  task :import, [:file, :change_path_reservation?, :update_existing?] => :environment do |_, args|
+    args.with_defaults(
+      change_path_reservation?: false,
+      update_existing?: false,
+    )
 
     data = CSV.read(args[:file])
 
     data.shift # Remove the CSV header
 
     created = 0
+    updated = 0
     skipped = 0
     errors = {}
 
@@ -31,28 +35,34 @@ namespace :redirects do
 
         redirect = Redirect.where(from_path: fields[:from_path]).first
 
-        if redirect.present?
+        if redirect.present? && !args[:update_existing?]
           skipped += 1
           print '-'
-        else
-          begin
-            if args[:change_path_reservation?]
-              publishing_api_client.put_path(
-                fields[:from_path],
-                publishing_app: 'short-url-manager',
-                override_existing: true,
-              )
-            end
+          next
+        end
 
+        begin
+          if args[:change_path_reservation?]
+            publishing_api_client.put_path(
+              fields[:from_path],
+              publishing_app: 'short-url-manager',
+              override_existing: true,
+            )
+          end
+
+          if redirect.present?
+            redirect.update!(fields)
+            updated += 1
+            print '*'
+          else
             Redirect.create!(fields)
-
             created += 1
             print '.'
-          rescue StandardError => e
-            errors[row] = e
-
-            print 'x'
           end
+        rescue StandardError => e
+          errors[row] = e
+
+          print 'x'
         end
       end
     rescue Interrupt
@@ -69,6 +79,7 @@ namespace :redirects do
     puts
     puts "Import finished:"
     puts "  - created: #{created}"
+    puts "  - updated: #{updated}"
     puts "  - skipped: #{skipped}"
     puts "  -  errors: #{errors.size}"
   end


### PR DESCRIPTION
Previously the redirects:import rake task just skipped existing
redirects. But this does not allow for fixing redirects that were
imported incorrectly, so add the ability to enable updating them.