### PR TITLE
Allow advanced users to override existing path reservations

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -96,10 +96,10 @@ private
   end
 
   def create_short_url_request_params
-    params[:short_url_request].permit(:from_path, :to_path, :reason, :route_type, :segments_mode, :organisation_slug, :confirmed)
+    params[:short_url_request].permit(:from_path, :to_path, :reason, :route_type, :segments_mode, :organisation_slug, :override_existing, :confirmed)
   end
 
   def update_short_url_request_params
-    params[:short_url_request].permit(:to_path, :reason, :route_type, :segments_mode, :organisation_slug)
+    params[:short_url_request].permit(:to_path, :reason, :route_type, :segments_mode, :override_existing, :organisation_slug)
   end
 end

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -8,6 +8,7 @@ class ShortUrlRequest
   field :to_path, type: String
   field :route_type, type: String, default: 'exact'
   field :segments_mode, type: String, default: 'ignore'
+  field :override_existing, type: Boolean, default: false
   field :reason, type: String
   field :contact_email, type: String
   field :organisation_slug, type: String

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -50,6 +50,11 @@
     <h2>Advanced options</h2>
     <p>Leave as defaults if unsure.</p>
     <div class="form-group">
+      <%= f.label :override_existing %>
+      <%= f.select :override_existing, options_for_select({ "No" => false, "Yes" => true }, @short_url_request.override_existing), {}, class: 'form-control input-md-6' %>
+      <p>This will allow the redirect to override any existing content for this path. Be <strong>very careful</strong> with this option.</p>
+    </div>
+    <div class="form-group">
       <%= f.label 'From redirects' %>
       <%= f.select :route_type, options_for_select({ "Exact URL only" => "exact", "URL and all pages under it" => "prefix" }, @short_url_request.route_type), {}, class: 'form-control input-md-6' %>
       <p>Do not redirect all pages unless you need any page with an address which starts with your input to also be redirected. For example, if you add <strong>gov.uk/address/</strong> then <strong>gov.uk/address/gone</strong> would also be redirected.</p>
@@ -73,6 +78,7 @@
     <p>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target?q=123</strong></p>
     <h5>Using "URL and all pages under it"</h5>
     <p>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target/page/?q=123</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target/doe/a/deer</strong></p>
+
   </fieldset>
   <% end %>
 <%- end -%>

--- a/app/views/short_url_requests/_short_url_request_data.html.erb
+++ b/app/views/short_url_requests/_short_url_request_data.html.erb
@@ -13,6 +13,9 @@
   <dt>Target URL:</dt>
   <dd><%= link_to short_url_request.to_path, govuk_url_for(short_url_request.to_path) %></dd>
 
+  <dt>Override existing:</dt>
+  <dd><%= short_url_request.override_existing? ? "Yes" : "No" %></dd>
+
   <dt>Route type:</dt>
   <dd><%= short_url_request.route_type %></dd>
 

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -31,8 +31,8 @@
       <h2>You cannot accept this redirect request at the moment</h2>
     </div>
     <div class="panel-body">
-      Accepting redirect requests with a type of 'prefix', or a
-      segments mode of 'ignore' is currently disabled for most users,
+      Accepting redirect requests with 'override existing', a type of 'prefix',
+      or a segments mode of 'ignore' is currently disabled for most users,
       as this functionality is still being developed.
     </div>
   </div>

--- a/lib/commands/short_url_requests/accept.rb
+++ b/lib/commands/short_url_requests/accept.rb
@@ -12,7 +12,7 @@ class Commands::ShortUrlRequests::Accept
     # can't as the tests fail - seems the `try` version still retains a proxy
     existing_request = redirect.short_url_request.nil? ? nil : redirect.short_url_request.target
 
-    if redirect.update_attributes(to_path: url_request.to_path, short_url_request: url_request)
+    if redirect.update_attributes(to_path: url_request.to_path, short_url_request: url_request, override_existing: url_request.override_existing)
       url_request.update_attribute(:state, 'accepted')
       existing_request.update_attribute(:state, 'superseded') if existing_request.present?
       Notifier.short_url_request_accepted(url_request).deliver_now

--- a/spec/lib/commands/short_url_requests/accept_spec.rb
+++ b/spec/lib/commands/short_url_requests/accept_spec.rb
@@ -11,7 +11,7 @@ describe Commands::ShortUrlRequests::Accept do
       command.call(failure: failure)
 
       expect(url_request.redirect).not_to be_nil
-      expect(url_request.redirect.attributes.slice(:from_path, :to_path)).to eq(url_request.attributes.slice(:from_path, :to_path))
+      expect(url_request.redirect.attributes.slice(:from_path, :to_path, :override_existing)).to eq(url_request.attributes.slice(:from_path, :to_path, :override_existing))
     end
 
     it "changes request state to accepted" do

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -1,9 +1,11 @@
 require 'rails_helper'
 require 'gds_api/test_helpers/publishing_api_v2'
+require 'gds_api/test_helpers/publishing_api'
 require "securerandom"
 
 describe Redirect do
   include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::PublishingApi
   include PublishingApiHelper
 
   include_examples "ShortUrlValidations", :redirect
@@ -60,6 +62,20 @@ describe Redirect do
           redirect_hash = publishing_api_redirect_hash(redirect.from_path, redirect.to_path, redirect.route_type, redirect.segments_mode)
           assert_publishing_api_put_content(redirect.content_id, redirect_hash)
           assert_publishing_api_publish(redirect.content_id)
+        end
+      end
+
+      context "when override_existing is set" do
+        let(:redirect) { build :redirect, override_existing: true }
+        before(:context) { stub_default_publishing_api_path_reservation }
+
+        it "should put a publish intent to the publishing API" do
+          api_url = GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_ENDPOINT
+          assert_publishing_api_put(
+            "#{api_url}/paths#{redirect.from_path}",
+            publishing_app: 'short-url-manager',
+            override_existing: true
+)
         end
       end
 


### PR DESCRIPTION
Sometimes it is useful to be able to create a new redirect for a path that is currently occupied by content from a different app. This could happen for example when some content is removed and needs to be redirected to new content from a different publisher.

This change adds an "override existing" field to the advanced options on the URL request form, and when that is selected it explicitly sends a path reservation override to the publishing-api before creating the redirect.