### PR TITLE
Split "receive notifications" to a new permission.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Users must be given Signon permissions to access and use the features
 of this tool. The available permissions are:
 - `request_short_urls`: Can complete a form to request a new Short URL, which must be approved before being made
 - `manage_short_urls`: Can approve requests for Short URLs, and create the redirects on GOV.UK
+- `receive_notifications`: Will receive email notifications when a new short URL is requested.
 - `advanced_options`: Can create and approve requests using advanced options (prefix type redirects, and non-default segments mode values).
 
 ## Licence

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -4,7 +4,7 @@ class Notifier < ActionMailer::Base
 
   def short_url_requested(short_url_request)
     @short_url_request = short_url_request
-    to = User.short_url_managers.map(&:email)
+    to = User.notification_recipients.map(&:email)
     subject = "#{prefix}Short URL request for '#{short_url_request.from_path}' by #{short_url_request.organisation_title}"
     mail to: to, subject: subject
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User
   field :organisation_content_id, type: String
 
   scope :short_url_managers, -> { where(permissions: /manage_short_urls/) }
+  scope :notification_recipients, -> { where(permissions: /receive_notifications/) }
 
   def can_request_short_urls?
     permissions.include? 'request_short_urls'

--- a/spec/factories/user_factories.rb
+++ b/spec/factories/user_factories.rb
@@ -12,7 +12,15 @@ FactoryGirl.define do
     permissions %w(signin manage_short_urls)
   end
 
+  factory :short_url_manager_and_recipient, parent: :user do
+    permissions %w(signin manage_short_urls receive_notifications)
+  end
+
+  factory :notification_recipient, parent: :user do
+    permissions %w(signin receive_notifications)
+  end
+
   factory :short_url_requester_and_manager, parent: :user do
-    permissions %w(signin request_short_urls manage_short_urls)
+    permissions %w(signin request_short_urls manage_short_urls receive_notifications)
   end
 end

--- a/spec/features/publisher_requests_a_furl_spec.rb
+++ b/spec/features/publisher_requests_a_furl_spec.rb
@@ -4,11 +4,11 @@ feature "As a publisher, I can request a short URL" do
   background do
     create :organisation, title: 'Ministry of Magic', slug: 'ministry-of-magic'
     create :organisation, title: 'Ministry of Beards', slug: 'ministry-of-beards'
-    create :short_url_manager, email: "short-url-manager-1@example.com"
+    create :notification_recipient, email: "short-url-manager-1@example.com"
     login_as create(:short_url_requester, name: "Gandalf", email: "gandalf@example.com", organisation_slug: "ministry-of-magic")
   end
 
-  scenario "Publisher requests a short_url, and short_url managers are notified" do
+  scenario "Publisher requests a short_url, and notification_recipients are notified" do
     visit "/"
     click_on "Request a new URL redirect or short URL"
 

--- a/spec/lib/commands/short_url_requests/create_spec.rb
+++ b/spec/lib/commands/short_url_requests/create_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Commands::ShortUrlRequests::Create do
-  let(:user) { create(:short_url_manager) }
+  let(:user) { create(:short_url_manager_and_recipient) }
   subject(:command) { described_class.new(params, user) }
 
   let(:success) { double(:success, call: true) }

--- a/spec/mailers/notifier_spec.rb
+++ b/spec/mailers/notifier_spec.rb
@@ -58,8 +58,8 @@ describe Notifier do
       expect(mail).to have_body_content "You can respond to this request here: #{Plek.current.find('short-url-manager') + short_url_request_path(short_url_request)}"
     end
 
-    context "with several users with permissions to manage short_urls" do
-      let!(:users) { 3.times.map { create :short_url_manager } }
+    context "with several users with permissions to receive notifications" do
+      let!(:users) { 3.times.map { create :notification_recipient } }
 
       it "should send to all users with the request_short_urls permission" do
         expect(mail.to).to include users[0].email


### PR DESCRIPTION
As this app is becoming the official way to create redirects, replacing
router-data, developers and 2nd line need permissions to do this
directly. At present, though, granting the "manage_short_urls"
permission also adds the user to the list of recipients of email requests
for new URLs from departments, which is unnecessary.

This change therefore uses a new permission, "receive_notifications", to
determine the list of users who will be notified by email when a URL is
requested. Ability to actually approve the request remains with the
"manage_short_urls" permission as before; so those with the former
permission will usually need the latter, but the reverse is not true.

Before deployment a separate change will be necessary in signon to add
the new permission and assign it to the current list of short URL
managers.