### PR TITLE
ShortUrlRequest association with requester is optional

### DIFF
--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -15,7 +15,7 @@ class ShortUrlRequest
   field :organisation_title, type: String
   field :rejection_reason, type: String
 
-  belongs_to :requester, class_name: "User"
+  belongs_to :requester, class_name: "User", optional: true
   has_one :redirect
 
   validates :state, :reason, :contact_email, :organisation_slug, :organisation_title, presence: true

--- a/spec/models/short_url_request_spec.rb
+++ b/spec/models/short_url_request_spec.rb
@@ -11,6 +11,10 @@ describe ShortUrlRequest do
     specify { expect(build(:short_url_request, organisation_title: '')).to_not be_valid }
     specify { expect(build(:short_url_request, organisation_slug: '')).to_not be_valid }
 
+    it "should not require a requester association" do
+      expect(build(:short_url_request, requester: nil)).to be_valid
+    end
+
     it "should allow 'pending', 'accepted', 'rejected', and 'superseded' as acceptable state values" do
       expect(build(:short_url_request, state: 'pending')).to be_valid
       expect(build(:short_url_request, state: 'accepted')).to be_valid


### PR DESCRIPTION
With Rails 5 the `belongs_to` association was changed from having the
optional property default from true to false. This means that we now
receive validation errors when we try to update many records in the
database.

This switches this back to the previous behaviour. As per:
https://blog.bigbinary.com/2016/02/15/rails-5-makes-belong-to-association-required-by-default.html