### PR TITLE
Fix segments mode preserve

### DIFF
--- a/app/views/short_url_requests/confirmation.html.erb
+++ b/app/views/short_url_requests/confirmation.html.erb
@@ -4,6 +4,11 @@
   <%= f.hidden_field :organisation_slug %>
   <%= f.hidden_field :reason %>
   <%= f.hidden_field :confirmed, value: true %>
+  <% if allow_use_of_advanced_options? %>
+    <%= f.hidden_field :override_existing %>
+    <%= f.hidden_field :route_type %>
+    <%= f.hidden_field :segments_mode %>
+  <% end %>
   <% if would_overwrite_existing?(@short_url_request) %>
     <h1>Redirects for that URL redirect or short URL already exist!</h1>
   <% else %>

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -16,7 +16,7 @@ if Rails.env.development?
   #
   GDS::SSO.test_user = User.find_or_create_by(email: 'user@test.example').tap do |u|
     u.name = 'Test User'
-    u.permissions = %w(signin manage_short_urls request_short_urls)
+    u.permissions = %w(signin manage_short_urls request_short_urls advanced_options)
     u.save!
   end
 end

--- a/lib/commands/short_url_requests/accept.rb
+++ b/lib/commands/short_url_requests/accept.rb
@@ -12,7 +12,7 @@ class Commands::ShortUrlRequests::Accept
     # can't as the tests fail - seems the `try` version still retains a proxy
     existing_request = redirect.short_url_request.nil? ? nil : redirect.short_url_request.target
 
-    if redirect.update_attributes(to_path: url_request.to_path, short_url_request: url_request, override_existing: url_request.override_existing)
+    if redirect.update_attributes(to_path: url_request.to_path, short_url_request: url_request, override_existing: url_request.override_existing, route_type: url_request.route_type, segments_mode: url_request.segments_mode)
       url_request.update_attribute(:state, 'accepted')
       existing_request.update_attribute(:state, 'superseded') if existing_request.present?
       Notifier.short_url_request_accepted(url_request).deliver_now

--- a/spec/lib/commands/short_url_requests/accept_spec.rb
+++ b/spec/lib/commands/short_url_requests/accept_spec.rb
@@ -11,13 +11,36 @@ describe Commands::ShortUrlRequests::Accept do
       command.call(failure: failure)
 
       expect(url_request.redirect).not_to be_nil
-      expect(url_request.redirect.attributes.slice(:from_path, :to_path, :override_existing)).to eq(url_request.attributes.slice(:from_path, :to_path, :override_existing))
+      expect(url_request.redirect.attributes.slice(:from_path, :to_path, :override_existing, :segments_mode)).to eq(url_request.attributes.slice(:from_path, :to_path, :override_existing, :route_type, :segments_mode))
     end
 
     it "changes request state to accepted" do
       command.call(failure: failure)
 
       expect(url_request).to be_accepted
+    end
+  end
+
+  context "with advanced options" do
+    let(:advanced_request) { create(:short_url_request, from_path: "/a-friendly-url", route_type: "prefix", segments_mode: "preserve") }
+    let(:advanced_accept) { described_class.new(advanced_request) }
+
+    it "creates a redirect with route type of 'prefix'" do
+      advanced_accept.call(failure: failure)
+      expect(advanced_request.redirect).not_to be_nil
+
+      redirect = Redirect.find_by(from_path: "/a-friendly-url")
+
+      expect(redirect.route_type).to eq("prefix")
+    end
+
+    it "creates a redirect with segment mode of 'preserve'" do
+      advanced_accept.call(failure: failure)
+      expect(advanced_request.redirect).not_to be_nil
+
+      redirect = Redirect.find_by(from_path: "/a-friendly-url")
+
+      expect(redirect.segments_mode).to eq("preserve")
     end
   end
 

--- a/spec/lib/commands/short_url_requests/create_spec.rb
+++ b/spec/lib/commands/short_url_requests/create_spec.rb
@@ -140,4 +140,32 @@ describe Commands::ShortUrlRequests::Create do
       end
     end
   end
+
+  context "with advanced options" do
+    let(:params) {
+      {
+        from_path: "/a-friendly-url",
+        to_path: "/somewhere/a-document",
+        reason: "Because wombles",
+        organisation_slug: organisation.slug,
+        confirmed: true,
+        route_type: "exact",
+        segments_mode: "preserve",
+        override_existing: false
+      }
+    }
+
+    it "creates a redirect with segment mode of 'preserve'" do
+      command.call(
+        success: success,
+        failure: failure,
+        confirmation_required: confirmation_required,
+      )
+
+      expect(success).to have_received(:call).once.with(instance_of(ShortUrlRequest))
+      request = ShortUrlRequest.find_by(from_path: "/a-friendly-url")
+
+      expect(request.segments_mode).to eq("preserve")
+    end
+  end
 end


### PR DESCRIPTION
When using the segments mode advanced option, we were never able to set it to anything other than the default value of "ignore" because we weren't setting it correctly when we accepted a pending Short Url Request.

We were also not passing on these values when we showed the confirmation screen.