### PR TITLE
Retire design principles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'rails', '~> 5.1'
 gem 'sass-rails', '~> 5.0'
 
 gem 'mongoid', '6.0.2'
-gem 'mongoid_rails_migrations', '~> 1.0.1'
+gem 'mongoid_rails_migrations', git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix"
 
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '~> 3.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/alphagov/mongoid_rails_migrations
+  revision: 7dc2c19549698f5666d2a91e89a9845480e852c4
+  branch: avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix
+  specs:
+    mongoid_rails_migrations (1.1.0)
+      activesupport (>= 4.2.0)
+      bundler (>= 1.0.0)
+      mongoid (>= 4.0.0)
+      rails (>= 4.2.0)
+      railties (>= 4.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -145,11 +157,6 @@ GEM
     mongoid (6.0.2)
       activemodel (~> 5.0)
       mongo (~> 2.3)
-    mongoid_rails_migrations (1.0.1)
-      activesupport (>= 3.2.0)
-      bundler (>= 1.0.0)
-      rails (>= 3.2.0)
-      railties (>= 3.2.0)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -328,7 +335,7 @@ DEPENDENCIES
   logstasher (~> 0.5.3)
   mlanett-redis-lock (= 0.2.7)
   mongoid (= 6.0.2)
-  mongoid_rails_migrations (~> 1.0.1)
+  mongoid_rails_migrations!
   plek
   pry
   rails (~> 5.1)

--- a/db/migrate/20171113151034_create_redirects_for_design_principles.rb
+++ b/db/migrate/20171113151034_create_redirects_for_design_principles.rb
@@ -1,0 +1,114 @@
+class CreateRedirectsForDesignPrinciples < Mongoid::Migration
+  def self.up
+    # This URL has already been manually entered in short-url-manager
+    # "/design-principles/performanceframework" => "/government/publications/gds-performance-framework"
+
+    # These redirects taken from the current state of router and the routes
+    # that design-principles still serves directly
+    design_principles_redirects = {
+      # existing router redirects
+      '/design-principles'                                             => '/guidance/government-design-principles',
+      '/design-principles/detailedguides'                              => '/guidance/content-design/content-types',
+      '/design-principles/insidegovernment'                            => '/guidance/content-design/writing-for-gov-uk',
+      '/design-principles/mainstream'                                  => '/topic/government-digital-guidance/content-publishing',
+      '/design-principles/seo'                                         => '/guidance/content-design/writing-for-gov-uk',
+      '/design-principles/style-guide'                                 => '/topic/government-digital-guidance/content-publishing',
+      '/design-principles/style-guide/a-z'                             => '/guidance/style-guide/a-to-z-of-gov-uk-style',
+      '/design-principles/style-guide/answers'                         => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/benefits-and-schemes'            => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/case-studies'                    => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/consultations'                   => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/corporate-information'           => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/detailed-guides'                 => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/document-collections'            => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/government-responses'            => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/groups'                          => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/guides'                          => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/images'                          => '/guidance/content-design/image-copyright-standards-for-gov-uk',
+      '/design-principles/style-guide/news-stories-and-press-releases' => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/organisation-homepage'           => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/people-and-roles'                => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/policy-advisory-groups'          => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/policy-pages'                    => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/publications'                    => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/speeches'                        => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/statements-to-parliament'        => '/guidance/content-design/content-types',
+      '/design-principles/style-guide/style-points'                    => '/guidance/style-guide/a-to-z-of-gov-uk-style',
+      '/design-principles/style-guide/whats-new'                       => '/guidance/style-guide/updates',
+      '/design-principles/style-guide/writing-for-govuk'               => '/guidance/content-design/writing-for-gov-uk',
+      '/design-principles/style-guide/writing-for-the-web'             => '/guidance/content-design/writing-for-gov-uk',
+      '/design-principles/whatsnew'                                    => '/guidance/style-guide/updates',
+      '/designprinciples'                                              => '/guidance/government-design-principles',
+      '/designprinciples/styleguide'                                   => '/topic/government-digital-guidance/content-publishing',
+      # routes still served by design-principles
+      '/design-principles/accessiblepdfs'                              => '/guidance/how-to-publish-on-gov-uk/accessible-pdfs',
+      # This URL has already been manually entered in short-url-manager
+      # '/design-principles/performanceframework'                        => '/government/publications/gds-performance-framework'
+      # This URL will be turned into a gone to avoid polluting the formats (the updates page is not available as atom) (see below)
+      # '/design-principles/style-guide.atom'                            => '/guidance/style-guide/updates'
+    }
+
+    murray = User.find_by(email: 'murray.steele@digital.cabinet-office.gov.uk')
+    redirect_args = {
+      override_existing: true,
+      reason: 'Retiring design principles and making sure all redirects are consistent.  Note: this request is being created in a automated migration and will be automatically accepted.',
+      organisation_slug: 'government-digital-service',
+      confirmed: true
+    }
+    problems = {}
+    say_with_time('Creating and accepting short_url_requests for design-principles urls') do
+      design_principles_redirects.each do |from, to|
+        Commands::ShortUrlRequests::Create.new(
+          redirect_args.merge(from_path: from, to_path: to),
+          murray
+        ).call(
+          success: -> (url_request) {
+            Commands::ShortUrlRequests::Accept.new(
+              url_request
+            ).call(
+              failure: -> (url_request) {
+                problems[from] = 'Could not accept short_url_request'
+              }
+            )
+          },
+          confirmation_required: -> (url_request) {
+            problems[from] = "Even though we said it didn't matter this url still requires confirmation because there are others like it."
+          },
+          failure: -> (url_request) {
+            problems[from] = "Could not create short_url_request because: #{url_request.errors.full_messages}"
+          }
+        )
+      end
+    end
+
+    say_with_time('Issuing a GONE redirect for /design-principles/style-guide.atom which has no appropriate redirect') do
+      publishing_api.unpublish(
+        # this content_id extracted from the design-principles special routes publishing rake task
+        '7672ae7d-6efb-4816-bd74-c49a6cb43f04',
+        {
+          type: 'gone',
+          explanation: 'The design-principles application is being retired and there is no alternative for this content published in the ATOM format.',
+          alternative_path: '/guidance/style-guide/updates'
+        }
+      )
+    end
+
+    if problems.empty?
+      say "Success!  All design-principles urls created as short_url_requests and accepted as redirects."
+    else
+      say "Warning!  The following redirects could not be completed\n\n#{problems.map { |route, problem| " * #{route} -> #{problem}" }.join("\n")}"
+    end
+  end
+
+  def self.down
+    # this migration is data only and can't really be un-done as there's no
+    # concept in short-url-manager of deleting a redirect
+  end
+
+  def self.publishing_api
+    @publishing_api ||= GdsApi::PublishingApiV2.new(
+      Plek.current.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/M45WyUGZ/261-retire-design-principles

We use short-url-manager to create redirects for all the paths currently served, and ever handled by the design-principles app.  Most of these are handled by redirects published by the design-principles app, or that somehow exist in the router database via ad-hoc changes.  Pushing them through short-url-manager means we have a record of the change, and in an app that won't shortly be moved to the attic.