### PR TITLE
Remove details from /design-principles/style-guide.atom gone item

### DIFF
--- a/db/migrate/20171113151034_create_redirects_for_design_principles.rb
+++ b/db/migrate/20171113151034_create_redirects_for_design_principles.rb
@@ -86,9 +86,7 @@ class CreateRedirectsForDesignPrinciples < Mongoid::Migration
         # this content_id extracted from the design-principles special routes publishing rake task
         '7672ae7d-6efb-4816-bd74-c49a6cb43f04',
         {
-          type: 'gone',
-          explanation: 'The design-principles application is being retired and there is no alternative for this content published in the ATOM format.',
-          alternative_path: '/guidance/style-guide/updates'
+          type: 'gone'
         }
       )
     end


### PR DESCRIPTION
For: https://trello.com/c/M45WyUGZ/261-retire-design-principles

This is a follow up to #104 after we tried it on integration and spotted that
the `/design-principles/style-guide.atom` resulted in a 500 error from
government-frontend (see: https://sentry.io/govuk/app-government-frontend/issues/386977691/events/9310503605/)

The process for a gone item is to send an unpublishing to the
publishing-api.  This makes changes to the internal db of publishing-api
and then presents the unpublished content to the content-store.  This in
turn changes the internal db of the content-store and presents the changes
to the router.

For a gone item we tell router to set the handler to "gone", but not if it
has any details (like an explanation or alternate url).  If that is the
case we tell the router to set the handler to "backend" and change the
backend to "government-frontend".  This is because "government-frontend"
can handle rendering more complex gone items that the router can't.

The problem with `/design-principles/style-guide.atom` is that when the
request is handled by government-frontend it ignores the format and asks
content-store for the wrong content-item; `/design-principles/style-guide`
instead.  The app assumes that the format of the request is something we
to ignore in terms of talking to content-store and leave it up to the
standard rails content negotiation stuff; it's purely a presentational
concern.  In this case however, that is not true:
`/design-principles/style-guide` is a redirect to some other content, but
`/design-principles/style-guide.atom` is a gone item because there is no
valid replacement in that format.

If we remove the explanation and alternative url from the unpublishing
then the gone item sent to router is a simple one with the handler set to
"gone" and we avoid this issue.