### PR TITLE
Use correct arguments for Sentry

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -35,7 +35,7 @@ private
     publishing_api.put_content(content_id, payload)
     publishing_api.publish(content_id, :major)
   rescue GdsApi::HTTPErrorResponse => e
-    GovukError.notify(e, params: payload)
+    GovukError.notify(e, extra: payload)
     errors.add(:base, "An error posting to the publishing API prevented this redirect from being created: #{e}")
     throw :abort # Do not continue to save
   end


### PR DESCRIPTION
`params` isn’t valid, but `extra` is. This was preventing us logging
errors to Sentry and seeing the real errors in the application.