### PR TITLE
Allow editing a request without a redirect change

### DIFF
--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -63,11 +63,12 @@ private
   def not_already_live
     if Redirect
          .where(
-           from_path: from_path,
-           to_path: to_path,
-           route_type: route_type,
-           segments_mode: segments_mode,
-           override_existing: override_existing,
+           :from_path => from_path,
+           :to_path => to_path,
+           :route_type => route_type,
+           :segments_mode => segments_mode,
+           :override_existing => override_existing,
+           :short_url_request.ne => self,
          )
          .exists?
       errors.add(:base, 'The specified Short URL already redirects to the specified Target URL')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,9 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :file delivery method writes emails that would be sent to the
+  # application log file
+  config.action_mailer.delivery_method = :file
 end

--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -16,7 +16,7 @@ if Rails.env.development?
   #
   GDS::SSO.test_user = User.find_or_create_by(email: 'user@test.example').tap do |u|
     u.name = 'Test User'
-    u.permissions = %w(signin manage_short_urls request_short_urls advanced_options)
+    u.permissions = %w(signin manage_short_urls request_short_urls advanced_options receive_notifications)
     u.save!
   end
 end

--- a/spec/models/short_url_request_spec.rb
+++ b/spec/models/short_url_request_spec.rb
@@ -31,10 +31,19 @@ describe ShortUrlRequest do
     end
 
     context "with a pre-existing redirect" do
-      before { create(:redirect, from_path: '/a-path', to_path: '/b-path') }
-
       it "is invalid" do
+        create(:redirect, from_path: '/a-path', to_path: '/b-path')
         expect(build(:short_url_request, from_path: '/a-path', to_path: '/b-path')).not_to be_valid
+      end
+
+      it "is valid if the request owns that redirect" do
+        request = create(:short_url_request,
+                         from_path: '/a-path',
+                         to_path: '/b-path',
+                         state: 'accepted')
+        create(:redirect, from_path: '/a-path', to_path: '/b-path', short_url_request: request)
+
+        expect(request).to be_valid
       end
     end
   end


### PR DESCRIPTION
This resolves an issue where users could not edit a request once the
request was accepted as the validator thought a redirect already
existed.

This has been done to resolve this 2nd link zendesk ticket: https://govuk.zendesk.com/agent/tickets/3806774

It also includes a couple of fixes for things I found while running the app for the first time.