### PR TITLE
Add ability to unpublish a redirect

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -18,6 +18,7 @@ class Redirect
   validates :from_path, uniqueness: true
 
   before_save :create_redirect_in_publishing_api
+  before_destroy :unpublish_in_publishing_api
   after_initialize :ensure_presence_of_content_id
 
 private
@@ -39,6 +40,9 @@ private
     throw :abort # Do not continue to save
   end
 
+  def unpublish_in_publishing_api
+    GdsApi.publishing_api_v2.unpublish(content_id, type: "gone")
+  end
 
   def ensure_presence_of_content_id
     self.content_id ||= SecureRandom.uuid

--- a/lib/tasks/redirect.rake
+++ b/lib/tasks/redirect.rake
@@ -1,0 +1,7 @@
+namespace :redirect do
+  desc "Destroy and unpublish a redirect."
+  task :destroy, %i[content_id] => :environment do |_, args|
+    content_id = args.fetch(:content_id)
+    Redirect.find_by!(content_id: content_id).destroy
+  end
+end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -103,4 +103,13 @@ describe Redirect do
       end
     end
   end
+
+  context "when destroying a redirect" do
+    subject(:redirect) { create(:redirect) }
+
+    it "unpublishing from the Publishing API" do
+      redirect.destroy
+      assert_publishing_api_unpublish(redirect.content_id, type: "gone")
+    end
+  end
 end

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -111,5 +111,14 @@ describe Redirect do
       redirect.destroy
       assert_publishing_api_unpublish(redirect.content_id, type: "gone")
     end
+
+    context "when unpublishing fails" do
+      it "fails to destroy" do
+        stub_any_publishing_api_call
+        redirect = create(:redirect)
+        stub_publishing_api_isnt_available
+        expect { redirect.destroy }.to raise_error(GdsApi::HTTPUnavailable)
+      end
+    end
   end
 end


### PR DESCRIPTION
This will make it easier to handle support requests to remove a redirect.

An example ticket: https://govuk.zendesk.com/agent/tickets/3813666