### PR TITLE
Use `rubocop-govuk` instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
-AllCops:
-  TargetRubyVersion: 2.3
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+
 Style/ConditionalAssignment:
   Exclude:
     - 'config/initializers/instance_name.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,3 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
-Style/ConditionalAssignment:
-  Exclude:
-    - 'config/initializers/instance_name.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,8 @@ inherit_gem:
     - config/default.yml
     - config/rails.yml
 
+# I don't understand what value
+# https://rails.rubystyle.guide/#has_many-has_one-dependent-option
+# adds, so disable this cop. There's only one offense.
+Rails/HasManyOrHasOneDependent:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ group :development, :test do
   gem "simplecov-rcov", "~> 0.2.3", require: false
   gem "webmock", "~> 3.8.2", require: false
 
+  gem "rubocop-govuk"
   gem "byebug"
   gem "govuk-content-schema-test-helpers"
-  gem "govuk-lint"
   gem "pry"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -36,4 +36,5 @@ group :development, :test do
   gem "govuk-content-schema-test-helpers"
   gem "pry"
   gem "rubocop-govuk"
+  gem "scss_lint-govuk"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,8 @@ group :development, :test do
   gem "simplecov-rcov", "~> 0.2.3", require: false
   gem "webmock", "~> 3.8.2", require: false
 
-  gem "rubocop-govuk"
   gem "byebug"
   gem "govuk-content-schema-test-helpers"
   gem "pry"
+  gem "rubocop-govuk"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,11 +114,6 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_admin_template (6.7.0)
       bootstrap-sass (= 3.4.1)
       jquery-rails (~> 4.3.1)
@@ -198,8 +193,8 @@ GEM
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    parallel (1.18.0)
-    parser (2.6.5.0)
+    parallel (1.19.1)
+    parser (2.7.0.3)
       ast (~> 2.4.0)
     plek (3.0.0)
     pry (0.12.2)
@@ -242,9 +237,6 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.1)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     redis (4.1.3)
     regexp_parser (1.6.0)
     request_store (1.5.0)
@@ -271,25 +263,24 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
-    rubocop (0.76.0)
+    rubocop (0.77.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.3.2)
+    rubocop-govuk (2.0.0)
+      rubocop (= 0.77)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.36.0)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.0.1)
@@ -301,8 +292,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.18.5)
@@ -329,7 +318,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.6)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.6.1)
     unicorn (5.5.3)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -364,7 +353,6 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso (~> 14.2.0)
   govuk-content-schema-test-helpers
-  govuk-lint
   govuk_admin_template (~> 6.7)
   govuk_app_config (~> 2.0.3)
   gretel (= 3.0.9)
@@ -377,6 +365,7 @@ DEPENDENCIES
   rails-controller-testing
   redis (= 4.1.3)
   rspec-rails (~> 3.9.0)
+  rubocop-govuk
   sass-rails (~> 6.0)
   simplecov (~> 0.18.5)
   simplecov-rcov (~> 0.2.3)
@@ -386,4 +375,4 @@ DEPENDENCIES
   will_paginate_mongoid (~> 2.0.1)
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,9 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.1)
     rake (13.0.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     redis (4.1.3)
     regexp_parser (1.6.0)
     request_store (1.5.0)
@@ -281,6 +284,11 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.0.1)
@@ -292,6 +300,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scss_lint (0.59.0)
+      sass (~> 3.5, >= 3.5.5)
+    scss_lint-govuk (0.2.0)
+      scss_lint
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.18.5)
@@ -367,6 +379,7 @@ DEPENDENCIES
   rspec-rails (~> 3.9.0)
   rubocop-govuk
   sass-rails (~> 6.0)
+  scss_lint-govuk
   simplecov (~> 0.18.5)
   simplecov-rcov (~> 0.2.3)
   uglifier (~> 4.2.0)

--- a/app/assets/stylesheets/layouts/_application.scss
+++ b/app/assets/stylesheets/layouts/_application.scss
@@ -8,11 +8,11 @@ $flash-success-bg-colour: #00823b;
   padding: 0;
 
   li {
-    color: $flash-colour;
     background-color: $flash-bg-colour;
+    color: $flash-colour;
     font-size: 16px;
-    padding: 10px 15px;
     margin-bottom: 2px;
+    padding: 10px 15px;
 
     &.success {
       background-color: $flash-success-bg-colour;

--- a/app/assets/stylesheets/layouts/_application.scss
+++ b/app/assets/stylesheets/layouts/_application.scss
@@ -1,6 +1,6 @@
 $flash-colour: #333;
 $flash-bg-colour: #ccc;
-$flash-success-colour: #ffffff;
+$flash-success-colour: #fff;
 $flash-success-bg-colour: #00823B;
 
 .flash-messages {

--- a/app/assets/stylesheets/layouts/_application.scss
+++ b/app/assets/stylesheets/layouts/_application.scss
@@ -1,7 +1,7 @@
 $flash-colour: #333;
 $flash-bg-colour: #ccc;
 $flash-success-colour: #fff;
-$flash-success-bg-colour: #00823B;
+$flash-success-bg-colour: #00823b;
 
 .flash-messages {
   list-style-type: none;

--- a/app/assets/stylesheets/modules/_clickable_row.scss
+++ b/app/assets/stylesheets/modules/_clickable_row.scss
@@ -2,9 +2,9 @@
   padding: 0;
 
   a {
+    color: inherit;
     display: block;
     padding: 8px;
     text-decoration: none;
-    color: inherit;
   }
 }

--- a/app/assets/stylesheets/views/shared/_form_errors.scss
+++ b/app/assets/stylesheets/views/shared/_form_errors.scss
@@ -4,16 +4,16 @@ $error-colour: #a94442;
 .form-errors {
   border: solid 1px $error-border-colour;
   border-radius: 3px;
-  padding: 15px;
   color: $error-colour;
   margin-bottom: 20px;
+  padding: 15px;
 
   p {
     font-weight: bold;
   }
 
   ul {
-    padding-left: 18px;
     margin-bottom: 0;
+    padding-left: 18px;
   }
 }

--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -90,7 +90,7 @@ private
   def get_short_url_request
     @short_url_request = ShortUrlRequest.find(params[:id])
   rescue Mongoid::Errors::DocumentNotFound
-    render plain: "Not found", status: 404
+    render plain: "Not found", status: :not_found
   end
 
   def create_short_url_request_params

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,2 @@
+class ApplicationMailer < ActionMailer::Base
+end

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -1,4 +1,4 @@
-class Notifier < ActionMailer::Base
+class Notifier < ApplicationMailer
   add_template_helper UrlHelper
   default from: '"Short URL manager" <noreply+short-url-manager@digital.cabinet-office.gov.uk>'
 

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -13,7 +13,7 @@ class Redirect
   field :segments_mode, type: String, default: "ignore"
   field :override_existing, type: Boolean, default: false
 
-  belongs_to :short_url_request, required: false
+  belongs_to :short_url_request, optional: true
 
   validates :from_path, uniqueness: true
 

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -77,7 +77,7 @@ private
   end
 
   def retrieve_organisation_title
-    self.organisation_title = Organisation.where(slug: organisation_slug).first.try(:title)
+    self.organisation_title = Organisation.find_by(slug: organisation_slug).try(:title)
   end
 
   def strip_whitespace

--- a/config/initializers/instance_name.rb
+++ b/config/initializers/instance_name.rb
@@ -1,7 +1,7 @@
 # Human-friendly name for this signon instance. This is used when generating
 # emails that need to disambiguate between instances.
-if Rails.env.development? || Rails.env.test?
-  Rails.application.config.instance_name = "development"
-else
-  Rails.application.config.instance_name = ENV.fetch("INSTANCE_NAME", nil)
-end
+Rails.application.config.instance_name = if Rails.env.development? || Rails.env.test?
+                                           "development"
+                                         else
+                                           ENV.fetch("INSTANCE_NAME", nil)
+                                         end

--- a/lib/commands/short_url_requests/accept.rb
+++ b/lib/commands/short_url_requests/accept.rb
@@ -12,7 +12,7 @@ class Commands::ShortUrlRequests::Accept
     # can't as the tests fail - seems the `try` version still retains a proxy
     existing_request = redirect.short_url_request.nil? ? nil : redirect.short_url_request.target
 
-    if redirect.update_attributes(to_path: url_request.to_path, short_url_request: url_request, override_existing: url_request.override_existing, route_type: url_request.route_type, segments_mode: url_request.segments_mode)
+    if redirect.update(to_path: url_request.to_path, short_url_request: url_request, override_existing: url_request.override_existing, route_type: url_request.route_type, segments_mode: url_request.segments_mode)
       url_request.update_attribute(:state, "accepted")
       existing_request.update_attribute(:state, "superseded") if existing_request.present?
       Notifier.short_url_request_accepted(url_request).deliver_now

--- a/lib/commands/short_url_requests/reject.rb
+++ b/lib/commands/short_url_requests/reject.rb
@@ -5,7 +5,7 @@ class Commands::ShortUrlRequests::Reject
   end
 
   def call
-    url_request.update_attributes(state: "rejected", rejection_reason: reason)
+    url_request.update(state: "rejected", rejection_reason: reason)
     Notifier.short_url_request_rejected(url_request).deliver_now
   end
 

--- a/lib/commands/short_url_requests/update.rb
+++ b/lib/commands/short_url_requests/update.rb
@@ -5,9 +5,9 @@ class Commands::ShortUrlRequests::Update
   end
 
   def call(success:, failure:)
-    if url_request.update_attributes(params)
+    if url_request.update(params)
       if url_request.redirect.present?
-        url_request.redirect.update_attributes(
+        url_request.redirect.update(
           from_path: url_request.from_path,
           to_path: url_request.to_path,
           route_type: url_request.route_type,

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,0 @@
-desc "Run govuk-lint with similar params to CI"
-task "lint" do
-  sh "govuk-lint-ruby --format clang Gemfile app config lib spec"
-end


### PR DESCRIPTION
- I'm doing this as part of the GOV.UK Developer Tooling group: https://trello.com/c/pR7GEFfU/128-make-all-current-govuk-repos-use-rubocop-govuk-instead-of-govuk-lint.
- The commit messages have more info.