### PR TITLE
Send short url request emails in batches

### DIFF
--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -2,28 +2,29 @@ class Notifier < ApplicationMailer
   add_template_helper UrlHelper
   default from: '"Short URL manager" <noreply+short-url-manager@digital.cabinet-office.gov.uk>'
 
-  def short_url_requested(short_url_request)
-    @short_url_request = short_url_request
-    to = User.notification_recipients.map(&:email)
+  def short_url_requested(short_url_request, recipients)
     subject = "#{prefix}Short URL request for '#{short_url_request.from_path}' by #{short_url_request.organisation_title}"
-    mail to: to, subject: subject
+    send_mail(recipients, subject, short_url_request)
   end
 
-  def short_url_request_accepted(short_url_request)
-    @short_url_request = short_url_request
-    to = Array(short_url_request.contact_email)
+  def short_url_request_accepted(short_url_request, recipients)
     subject = "#{prefix}Short URL request approved"
-    mail to: to, subject: subject
+    send_mail(recipients, subject, short_url_request)
   end
 
-  def short_url_request_rejected(short_url_request)
-    @short_url_request = short_url_request
-    to = Array(short_url_request.contact_email)
+  def short_url_request_rejected(short_url_request, recipients)
     subject = "#{prefix}Short URL request denied"
-    mail to: to, subject: subject
+    send_mail(recipients, subject, short_url_request)
   end
 
 private
+
+  attr_reader :short_url_request
+
+  def send_mail(to, subject, short_url_request)
+    @short_url_request = short_url_request
+    mail to: to, subject: subject
+  end
 
   def prefix
     "[#{Rails.application.config.instance_name}] " unless production?

--- a/app/services/request_notifier.rb
+++ b/app/services/request_notifier.rb
@@ -1,0 +1,20 @@
+class RequestNotifier
+  # AWS sets a max of 50 recipients
+  MAX_EMAIL_RECIPIENTS = 25
+
+  def self.email(event, short_url_request, mailer: Notifier)
+    recipients_for(event, short_url_request)
+      .in_groups_of(MAX_EMAIL_RECIPIENTS, false)
+      .map do |recipient_group|
+        mailer.send(event, short_url_request, recipient_group)
+      end
+  end
+
+  def self.recipients_for(event_category, short_url_request)
+    if event_category == :short_url_requested
+      User.notification_recipients.map(&:email)
+    else
+      Array(short_url_request.contact_email)
+    end
+  end
+end

--- a/lib/commands/short_url_requests/accept.rb
+++ b/lib/commands/short_url_requests/accept.rb
@@ -15,7 +15,7 @@ class Commands::ShortUrlRequests::Accept
     if redirect.update(to_path: url_request.to_path, short_url_request: url_request, override_existing: url_request.override_existing, route_type: url_request.route_type, segments_mode: url_request.segments_mode)
       url_request.update_attribute(:state, "accepted")
       existing_request.update_attribute(:state, "superseded") if existing_request.present?
-      Notifier.short_url_request_accepted(url_request).deliver_now
+      RequestNotifier.email(:short_url_request_accepted, url_request).each(&:deliver_now)
     else
       failure.call
     end

--- a/lib/commands/short_url_requests/create.rb
+++ b/lib/commands/short_url_requests/create.rb
@@ -12,7 +12,7 @@ class Commands::ShortUrlRequests::Create
     elsif requires_confirmation?(url_request)
       confirmation_required.call(url_request)
     elsif url_request.save
-      Notifier.short_url_requested(url_request).deliver_now
+      RequestNotifier.email(:short_url_requested, url_request).each(&:deliver_now)
       success.call(url_request)
     else
       failure.call(url_request)

--- a/lib/commands/short_url_requests/reject.rb
+++ b/lib/commands/short_url_requests/reject.rb
@@ -6,7 +6,7 @@ class Commands::ShortUrlRequests::Reject
 
   def call
     url_request.update(state: "rejected", rejection_reason: reason)
-    Notifier.short_url_request_rejected(url_request).deliver_now
+    RequestNotifier.email(:short_url_request_rejected, url_request).each(&:deliver_now)
   end
 
 private

--- a/spec/controllers/short_url_requests_controller_spec.rb
+++ b/spec/controllers/short_url_requests_controller_spec.rb
@@ -152,7 +152,7 @@ describe ShortUrlRequestsController do
       it "should send a short_url_requested notification" do
         mock_mail = double
         expect(mock_mail).to receive(:deliver_now)
-        expect(Notifier).to receive(:short_url_requested).with(kind_of(ShortUrlRequest)).and_return(mock_mail)
+        expect(RequestNotifier).to receive(:email).with(:short_url_requested, kind_of(ShortUrlRequest)).and_return([mock_mail])
         post :create, params: params
       end
 

--- a/spec/lib/commands/short_url_requests/reject_spec.rb
+++ b/spec/lib/commands/short_url_requests/reject_spec.rb
@@ -4,6 +4,7 @@ describe Commands::ShortUrlRequests::Reject do
   let(:url_request) { create(:short_url_request) }
   let(:reason) { "You weren't lucky today." }
   subject(:command) { described_class.new(url_request, reason) }
+  let(:user_email) { Array(url_request.contact_email) }
 
   it "rejects the request" do
     command.call
@@ -13,10 +14,10 @@ describe Commands::ShortUrlRequests::Reject do
   end
 
   it "sends a rejection email" do
-    allow(Notifier).to receive(:short_url_request_rejected).and_call_original
+    allow(RequestNotifier).to receive(:email).and_call_original
 
     command.call
 
-    expect(Notifier).to have_received(:short_url_request_rejected).once.with(url_request)
+    expect(RequestNotifier).to have_received(:email).once.with(:short_url_request_rejected, url_request)
   end
 end

--- a/spec/services/request_notifier_spec.rb
+++ b/spec/services/request_notifier_spec.rb
@@ -1,24 +1,29 @@
 require "rails_helper"
 
-describe Notifier do
+describe RequestNotifier do
+  include Rails.application.routes.url_helpers
+
   shared_examples_for "indicating the deployed environment via the subject line" do
     it "includes an indicator of the deployed environment in the subject line" do
       allow(Rails.application.config).to receive(:instance_name).and_return("testing-123")
-      expect(mail.subject).to match(/^\[testing-123\] Short URL request/)
+      expect(emails.first.subject).to match(/^\[testing-123\] Short URL request/)
     end
 
     it "does not include an indicator of the deployed environment in the subject line if it is blank (e.g. production)" do
       allow(Rails.application.config).to receive(:instance_name).and_return("")
-      expect(mail.subject).to match(/^Short URL request/)
+      expect(emails.first.subject).to match(/^Short URL request/)
     end
   end
 
-  describe "short_url_requested" do
+  let!(:notification_recipients) { 55.times.map { create :notification_recipient } }
+
+  describe "short url requested" do
     let!(:users) {
       [
         create(:short_url_manager),
       ]
     }
+
     let(:short_url_request_from_path) { "/somewhere" }
     let(:short_url_request_to_path) { "/somewhere/else" }
     let(:short_url_request_requester) { create(:short_url_requester) }
@@ -33,38 +38,40 @@ describe Notifier do
                             organisation_title: short_url_request_organisation_title,
                             reason: short_url_request_reason
     }
-    let(:mail) { Notifier.short_url_requested(short_url_request) }
+
+    let(:emails) { described_class.email(:short_url_requested, short_url_request) }
 
     it "should send from noreply+short-url-manager@digital.cabinet-office.gov.uk" do
-      expect(mail.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
+      expect(emails.first.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
     end
 
     it "should set a subject showing the from and applicable organisation" do
-      expect(mail.subject).to match(/#{Regexp.escape("Short URL request for '#{short_url_request_from_path}' by #{short_url_request_organisation_title}")}$/)
+      expect(emails.first.subject).to match(/#{Regexp.escape("Short URL request for '#{short_url_request_from_path}' by #{short_url_request_organisation_title}")}$/)
     end
 
     include_examples "indicating the deployed environment via the subject line"
 
     it "should include all relevant data in the body" do
-      expect(mail).to have_body_content "From: #{short_url_request_from_path}"
-      expect(mail).to have_body_content "To: #{short_url_request_to_path}"
-      expect(mail).to have_body_content "Requester: #{short_url_request_requester.name}"
-      expect(mail).to have_body_content "Contact email: #{short_url_request_contact_email}"
-      expect(mail).to have_body_content "Organisation: #{short_url_request_organisation_title}"
-      expect(mail).to have_body_content "Reason: #{short_url_request_reason}"
+      expect(emails.first).to have_body_content "From: #{short_url_request_from_path}"
+      expect(emails.first).to have_body_content "To: #{short_url_request_to_path}"
+      expect(emails.first).to have_body_content "Requester: #{short_url_request_requester.name}"
+      expect(emails.first).to have_body_content "Contact email: #{short_url_request_contact_email}"
+      expect(emails.first).to have_body_content "Organisation: #{short_url_request_organisation_title}"
+      expect(emails.first).to have_body_content "Reason: #{short_url_request_reason}"
     end
 
     it "includes a link to the short url request" do
-      expect(mail).to have_body_content "You can respond to this request here: #{Plek.new.external_url_for('short-url-manager') + short_url_request_path(short_url_request)}"
+      expect(emails.first).to have_body_content "You can respond to this request here: #{Plek.new.external_url_for('short-url-manager') + short_url_request_path(short_url_request)}"
     end
 
-    context "with several users with permissions to receive notifications" do
-      let!(:users) { 3.times.map { create :notification_recipient } }
-
+    context "with many users with permissions to receive notifications" do
       it "should send to all users with the request_short_urls permission" do
-        expect(mail.to).to include users[0].email
-        expect(mail.to).to include users[1].email
-        expect(mail.to).to include users[2].email
+        recipients = emails.map(&:to).flatten
+        expect(recipients).to match_array(notification_recipients.map(&:email))
+      end
+
+      it "should email users in batches of 25" do
+        expect(emails.count).to eq 3
       end
     end
   end
@@ -80,26 +87,26 @@ describe Notifier do
                                   redirect: build(:redirect, from_path: redirect_from_path,
                                                               to_path: redirect_to_path)
     }
-    let(:mail) { Notifier.short_url_request_accepted(short_url_request) }
+    let(:emails) { described_class.email(:short_url_request_accepted, short_url_request) }
 
     it "should send from noreply+short-url-manager@digital.cabinet-office.gov.uk" do
-      expect(mail.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
+      expect(emails.first.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
     end
 
     it "should sent to the contact email address supplied with the initial request" do
-      expect(mail.to).to be == ["bigglesworth@example.com"]
+      expect(emails.first.to).to be == ["bigglesworth@example.com"]
     end
 
     it "should set a subject" do
-      expect(mail.subject).to match(/Short URL request approved$/)
+      expect(emails.first.subject).to match(/Short URL request approved$/)
     end
 
     include_examples "indicating the deployed environment via the subject line"
 
     it "should address the user by name, and give the from path and to path in the email body" do
-      expect(mail).to have_body_content "Mr Bigglesworth"
-      expect(mail).to have_body_content "/evilhq"
-      expect(mail).to have_body_content "/favourite-hangouts/evil-headquarters"
+      expect(emails.first).to have_body_content "Mr Bigglesworth"
+      expect(emails.first).to have_body_content "/evilhq"
+      expect(emails.first).to have_body_content "/favourite-hangouts/evil-headquarters"
     end
   end
 
@@ -116,33 +123,33 @@ describe Notifier do
                                   to_path: short_url_request_to_path,
                                   rejection_reason: short_url_request_rejection_reason
     }
-    let(:mail) { Notifier.short_url_request_rejected(short_url_request) }
+    let(:emails) { described_class.email(:short_url_request_rejected, short_url_request) }
 
     it "should send from noreply+short-url-manager@digital.cabinet-office.gov.uk" do
-      expect(mail.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
+      expect(emails.first.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
     end
 
     it "should sent to the contact email address supplied with the initial request" do
-      expect(mail.to).to be == ["bigglesworth@example.com"]
+      expect(emails.first.to).to be == ["bigglesworth@example.com"]
     end
 
     it "should set a subject" do
-      expect(mail.subject).to match(/Short URL request denied$/)
+      expect(emails.first.subject).to match(/Short URL request denied$/)
     end
 
     include_examples "indicating the deployed environment via the subject line"
 
     it "should address the user by name, and give the from path and to path in the email body" do
-      expect(mail).to have_body_content "Mr Bigglesworth"
-      expect(mail).to have_body_content "/evilhq"
-      expect(mail).to have_body_content "/favourite-hangouts/evil-headquarters"
+      expect(emails.first).to have_body_content "Mr Bigglesworth"
+      expect(emails.first).to have_body_content "/evilhq"
+      expect(emails.first).to have_body_content "/favourite-hangouts/evil-headquarters"
     end
 
     context "when a reason is given" do
       let(:short_url_request_rejection_reason) { "The British government does not negotiate with terrorists" }
 
       it "should include the reason in the body content" do
-        expect(mail).to have_body_content "The British government does not negotiate with terrorists"
+        expect(emails.first).to have_body_content "The British government does not negotiate with terrorists"
       end
     end
 
@@ -150,7 +157,7 @@ describe Notifier do
       let(:short_url_request_rejection_reason) { nil }
 
       it "should state that no reason was given" do
-        expect(mail).to have_body_content "No reason was given"
+        expect(emails.first).to have_body_content "No reason was given"
       end
     end
   end


### PR DESCRIPTION
This will enable us to send users notification emails when there are more than 50 users.

AWS sets a max of 50 recipients, which we found out early one morning when we wanted to quickly create a new redirect.

This won't be necessary once we move to using Notify, but since there are still ~50 people signed up this is a quick fix for the meantime.

The `Notifier` mailer class now gets called by a new class `RequestNotifier` which handles the logic around who receives a notification email and sends the emails in batches.

I'm not super happy that this requires a new class, or that the new class exposes that there are multiple emails being sent, but it looks like a call to a mailer class is expected to result in a single email. If there's a better way please let me know.

```ruby
# Before:
Notifier.short_url_request_accepted(url_request).deliver_now

# After:
RequestNotifier.email(:short_url_requested, url_request).each(&:deliver_now)
```

https://trello.com/c/dDIZogjj/1422