### PR TITLE
Use the mail-notify gem to deliver via Notify instead of SES

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "gds-api-adapters"
 gem "gds-sso", "~> 14.3.0"
 gem "govuk_admin_template", "~> 6.7"
 gem "govuk_app_config", "~> 2.1.0"
+gem "mail-notify"
 gem "plek"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,9 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    mail-notify (1.0.1)
+      actionmailer (>= 5.0, < 6.1)
+      notifications-ruby-client (~> 5.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
@@ -177,6 +180,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (5.1.2)
+      jwt (>= 1.5, < 3)
     null_logger (0.0.1)
     oauth2 (1.4.4)
       faraday (>= 0.8, < 2.0)
@@ -370,6 +375,7 @@ DEPENDENCIES
   govuk_admin_template (~> 6.7)
   govuk_app_config (~> 2.1.0)
   gretel (= 3.0.9)
+  mail-notify
   mlanett-redis-lock (= 0.2.7)
   mongoid (= 6.2.1)
   mongoid_rails_migrations!

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -2,28 +2,29 @@ class Notifier < ApplicationMailer
   add_template_helper UrlHelper
   default from: '"Short URL manager" <noreply+short-url-manager@digital.cabinet-office.gov.uk>'
 
-  def short_url_requested(short_url_request)
-    @short_url_request = short_url_request
-    to = User.notification_recipients.map(&:email)
+  def short_url_requested(short_url_request, recipients)
     subject = "#{prefix}Short URL request for '#{short_url_request.from_path}' by #{short_url_request.organisation_title}"
-    mail to: to, subject: subject
+    send_mail(recipients, subject, short_url_request)
   end
 
-  def short_url_request_accepted(short_url_request)
-    @short_url_request = short_url_request
-    to = Array(short_url_request.contact_email)
+  def short_url_request_accepted(short_url_request, recipients)
     subject = "#{prefix}Short URL request approved"
-    mail to: to, subject: subject
+    send_mail(recipients, subject, short_url_request)
   end
 
-  def short_url_request_rejected(short_url_request)
-    @short_url_request = short_url_request
-    to = Array(short_url_request.contact_email)
+  def short_url_request_rejected(short_url_request, recipients)
     subject = "#{prefix}Short URL request denied"
-    mail to: to, subject: subject
+    send_mail(recipients, subject, short_url_request)
   end
 
 private
+
+  attr_reader :short_url_request
+
+  def send_mail(to, subject, short_url_request)
+    @short_url_request = short_url_request
+    mail to: to, subject: subject
+  end
 
   def prefix
     "[#{Rails.application.config.instance_name}] " unless production?

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -1,4 +1,4 @@
-class Notifier < ApplicationMailer
+class Notifier < Mail::Notify::Mailer
   add_template_helper UrlHelper
   default from: '"Short URL manager" <noreply+short-url-manager@digital.cabinet-office.gov.uk>'
 
@@ -23,7 +23,9 @@ private
 
   def send_mail(to, subject, short_url_request)
     @short_url_request = short_url_request
-    mail to: to, subject: subject
+    view_mail(ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID", "fake-test-template-id"),
+              to: to,
+              subject: subject)
   end
 
   def prefix

--- a/app/services/request_notifier.rb
+++ b/app/services/request_notifier.rb
@@ -1,6 +1,11 @@
 class RequestNotifier
-  # AWS sets a max of 50 recipients
+  # GOV.UK Notify sets a max of 1 recipient
   MAX_EMAIL_RECIPIENTS = 25
+
+  def initialize(short_url_request:, mailer: Notifier)
+    @mailer = mailer
+    @short_url_request = short_url_request
+  end
 
   def self.email(event, short_url_request, mailer: Notifier)
     recipients_for(event, short_url_request)

--- a/app/services/request_notifier.rb
+++ b/app/services/request_notifier.rb
@@ -1,0 +1,20 @@
+class RequestNotifier
+  # AWS sets a max of 50 recipients
+  MAX_EMAIL_RECIPIENTS = 25
+
+  def self.email(event, short_url_request, mailer: Notifier)
+    recipients_for(event, short_url_request)
+      .in_groups_of(MAX_EMAIL_RECIPIENTS, false)
+      .map do |recipient_group|
+        mailer.send(event, short_url_request, recipient_group)
+      end
+  end
+
+  def self.recipients_for(event_category, short_url_request)
+    if event_category == :short_url_requested
+      User.notification_recipients.map(&:email)
+    else
+      Array(short_url_request.contact_email)
+    end
+  end
+end

--- a/app/services/request_notifier.rb
+++ b/app/services/request_notifier.rb
@@ -1,6 +1,6 @@
 class RequestNotifier
   # GOV.UK Notify sets a max of 1 recipient
-  MAX_EMAIL_RECIPIENTS = 25
+  MAX_EMAIL_RECIPIENTS = 1
 
   def initialize(short_url_request:, mailer: Notifier)
     @mailer = mailer

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -59,6 +59,10 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "short_url_manager_#{Rails.env}"
   # config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :notify
+  config.action_mailer.notify_settings = {
+    api_key: ENV["GOVUK_NOTIFY_API_KEY"],
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/lib/commands/short_url_requests/accept.rb
+++ b/lib/commands/short_url_requests/accept.rb
@@ -15,7 +15,7 @@ class Commands::ShortUrlRequests::Accept
     if redirect.update(to_path: url_request.to_path, short_url_request: url_request, override_existing: url_request.override_existing, route_type: url_request.route_type, segments_mode: url_request.segments_mode)
       url_request.update_attribute(:state, "accepted")
       existing_request.update_attribute(:state, "superseded") if existing_request.present?
-      Notifier.short_url_request_accepted(url_request).deliver_now
+      RequestNotifier.email(:short_url_request_accepted, url_request).each(&:deliver_now)
     else
       failure.call
     end

--- a/lib/commands/short_url_requests/create.rb
+++ b/lib/commands/short_url_requests/create.rb
@@ -12,7 +12,7 @@ class Commands::ShortUrlRequests::Create
     elsif requires_confirmation?(url_request)
       confirmation_required.call(url_request)
     elsif url_request.save
-      Notifier.short_url_requested(url_request).deliver_now
+      RequestNotifier.email(:short_url_requested, url_request).each(&:deliver_now)
       success.call(url_request)
     else
       failure.call(url_request)

--- a/lib/commands/short_url_requests/reject.rb
+++ b/lib/commands/short_url_requests/reject.rb
@@ -6,7 +6,7 @@ class Commands::ShortUrlRequests::Reject
 
   def call
     url_request.update(state: "rejected", rejection_reason: reason)
-    Notifier.short_url_request_rejected(url_request).deliver_now
+    RequestNotifier.email(:short_url_request_rejected, url_request).each(&:deliver_now)
   end
 
 private

--- a/spec/controllers/short_url_requests_controller_spec.rb
+++ b/spec/controllers/short_url_requests_controller_spec.rb
@@ -152,7 +152,7 @@ describe ShortUrlRequestsController do
       it "should send a short_url_requested notification" do
         mock_mail = double
         expect(mock_mail).to receive(:deliver_now)
-        expect(Notifier).to receive(:short_url_requested).with(kind_of(ShortUrlRequest)).and_return(mock_mail)
+        expect(RequestNotifier).to receive(:email).with(:short_url_requested, kind_of(ShortUrlRequest)).and_return([mock_mail])
         post :create, params: params
       end
 

--- a/spec/lib/commands/short_url_requests/reject_spec.rb
+++ b/spec/lib/commands/short_url_requests/reject_spec.rb
@@ -4,6 +4,7 @@ describe Commands::ShortUrlRequests::Reject do
   let(:url_request) { create(:short_url_request) }
   let(:reason) { "You weren't lucky today." }
   subject(:command) { described_class.new(url_request, reason) }
+  let(:user_email) { Array(url_request.contact_email) }
 
   it "rejects the request" do
     command.call
@@ -13,10 +14,10 @@ describe Commands::ShortUrlRequests::Reject do
   end
 
   it "sends a rejection email" do
-    allow(Notifier).to receive(:short_url_request_rejected).and_call_original
+    allow(RequestNotifier).to receive(:email).and_call_original
 
     command.call
 
-    expect(Notifier).to have_received(:short_url_request_rejected).once.with(url_request)
+    expect(RequestNotifier).to have_received(:email).once.with(:short_url_request_rejected, url_request)
   end
 end

--- a/spec/services/request_notifier_spec.rb
+++ b/spec/services/request_notifier_spec.rb
@@ -1,24 +1,29 @@
 require "rails_helper"
 
-describe Notifier do
+describe RequestNotifier do
+  include Rails.application.routes.url_helpers
+
   shared_examples_for "indicating the deployed environment via the subject line" do
     it "includes an indicator of the deployed environment in the subject line" do
       allow(Rails.application.config).to receive(:instance_name).and_return("testing-123")
-      expect(mail.subject).to match(/^\[testing-123\] Short URL request/)
+      expect(emails.first.subject).to match(/^\[testing-123\] Short URL request/)
     end
 
     it "does not include an indicator of the deployed environment in the subject line if it is blank (e.g. production)" do
       allow(Rails.application.config).to receive(:instance_name).and_return("")
-      expect(mail.subject).to match(/^Short URL request/)
+      expect(emails.first.subject).to match(/^Short URL request/)
     end
   end
 
-  describe "short_url_requested" do
+  let!(:notification_recipients) { 55.times.map { create :notification_recipient } }
+
+  describe "short url requested" do
     let!(:users) {
       [
         create(:short_url_manager),
       ]
     }
+
     let(:short_url_request_from_path) { "/somewhere" }
     let(:short_url_request_to_path) { "/somewhere/else" }
     let(:short_url_request_requester) { create(:short_url_requester) }
@@ -33,38 +38,40 @@ describe Notifier do
                             organisation_title: short_url_request_organisation_title,
                             reason: short_url_request_reason
     }
-    let(:mail) { Notifier.short_url_requested(short_url_request) }
+
+    let(:emails) { described_class.email(:short_url_requested, short_url_request) }
 
     it "should send from noreply+short-url-manager@digital.cabinet-office.gov.uk" do
-      expect(mail.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
+      expect(emails.first.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
     end
 
     it "should set a subject showing the from and applicable organisation" do
-      expect(mail.subject).to match(/#{Regexp.escape("Short URL request for '#{short_url_request_from_path}' by #{short_url_request_organisation_title}")}$/)
+      expect(emails.first.subject).to match(/#{Regexp.escape("Short URL request for '#{short_url_request_from_path}' by #{short_url_request_organisation_title}")}$/)
     end
 
     include_examples "indicating the deployed environment via the subject line"
 
     it "should include all relevant data in the body" do
-      expect(mail).to have_body_content "From: #{short_url_request_from_path}"
-      expect(mail).to have_body_content "To: #{short_url_request_to_path}"
-      expect(mail).to have_body_content "Requester: #{short_url_request_requester.name}"
-      expect(mail).to have_body_content "Contact email: #{short_url_request_contact_email}"
-      expect(mail).to have_body_content "Organisation: #{short_url_request_organisation_title}"
-      expect(mail).to have_body_content "Reason: #{short_url_request_reason}"
+      expect(emails.first).to have_body_content "From: #{short_url_request_from_path}"
+      expect(emails.first).to have_body_content "To: #{short_url_request_to_path}"
+      expect(emails.first).to have_body_content "Requester: #{short_url_request_requester.name}"
+      expect(emails.first).to have_body_content "Contact email: #{short_url_request_contact_email}"
+      expect(emails.first).to have_body_content "Organisation: #{short_url_request_organisation_title}"
+      expect(emails.first).to have_body_content "Reason: #{short_url_request_reason}"
     end
 
     it "includes a link to the short url request" do
-      expect(mail).to have_body_content "You can respond to this request here: #{Plek.new.external_url_for('short-url-manager') + short_url_request_path(short_url_request)}"
+      expect(emails.first).to have_body_content "You can respond to this request here: #{Plek.new.external_url_for('short-url-manager') + short_url_request_path(short_url_request)}"
     end
 
-    context "with several users with permissions to receive notifications" do
-      let!(:users) { 3.times.map { create :notification_recipient } }
-
+    context "with many users with permissions to receive notifications" do
       it "should send to all users with the request_short_urls permission" do
-        expect(mail.to).to include users[0].email
-        expect(mail.to).to include users[1].email
-        expect(mail.to).to include users[2].email
+        recipients = emails.map(&:to).flatten
+        expect(recipients).to match_array(notification_recipients.map(&:email))
+      end
+
+      it "should email users in batches of 25" do
+        expect(emails.count).to eq 3
       end
     end
   end
@@ -80,26 +87,26 @@ describe Notifier do
                                   redirect: build(:redirect, from_path: redirect_from_path,
                                                               to_path: redirect_to_path)
     }
-    let(:mail) { Notifier.short_url_request_accepted(short_url_request) }
+    let(:emails) { described_class.email(:short_url_request_accepted, short_url_request) }
 
     it "should send from noreply+short-url-manager@digital.cabinet-office.gov.uk" do
-      expect(mail.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
+      expect(emails.first.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
     end
 
     it "should sent to the contact email address supplied with the initial request" do
-      expect(mail.to).to be == ["bigglesworth@example.com"]
+      expect(emails.first.to).to be == ["bigglesworth@example.com"]
     end
 
     it "should set a subject" do
-      expect(mail.subject).to match(/Short URL request approved$/)
+      expect(emails.first.subject).to match(/Short URL request approved$/)
     end
 
     include_examples "indicating the deployed environment via the subject line"
 
     it "should address the user by name, and give the from path and to path in the email body" do
-      expect(mail).to have_body_content "Mr Bigglesworth"
-      expect(mail).to have_body_content "/evilhq"
-      expect(mail).to have_body_content "/favourite-hangouts/evil-headquarters"
+      expect(emails.first).to have_body_content "Mr Bigglesworth"
+      expect(emails.first).to have_body_content "/evilhq"
+      expect(emails.first).to have_body_content "/favourite-hangouts/evil-headquarters"
     end
   end
 
@@ -116,33 +123,33 @@ describe Notifier do
                                   to_path: short_url_request_to_path,
                                   rejection_reason: short_url_request_rejection_reason
     }
-    let(:mail) { Notifier.short_url_request_rejected(short_url_request) }
+    let(:emails) { described_class.email(:short_url_request_rejected, short_url_request) }
 
     it "should send from noreply+short-url-manager@digital.cabinet-office.gov.uk" do
-      expect(mail.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
+      expect(emails.first.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
     end
 
     it "should sent to the contact email address supplied with the initial request" do
-      expect(mail.to).to be == ["bigglesworth@example.com"]
+      expect(emails.first.to).to be == ["bigglesworth@example.com"]
     end
 
     it "should set a subject" do
-      expect(mail.subject).to match(/Short URL request denied$/)
+      expect(emails.first.subject).to match(/Short URL request denied$/)
     end
 
     include_examples "indicating the deployed environment via the subject line"
 
     it "should address the user by name, and give the from path and to path in the email body" do
-      expect(mail).to have_body_content "Mr Bigglesworth"
-      expect(mail).to have_body_content "/evilhq"
-      expect(mail).to have_body_content "/favourite-hangouts/evil-headquarters"
+      expect(emails.first).to have_body_content "Mr Bigglesworth"
+      expect(emails.first).to have_body_content "/evilhq"
+      expect(emails.first).to have_body_content "/favourite-hangouts/evil-headquarters"
     end
 
     context "when a reason is given" do
       let(:short_url_request_rejection_reason) { "The British government does not negotiate with terrorists" }
 
       it "should include the reason in the body content" do
-        expect(mail).to have_body_content "The British government does not negotiate with terrorists"
+        expect(emails.first).to have_body_content "The British government does not negotiate with terrorists"
       end
     end
 
@@ -150,7 +157,7 @@ describe Notifier do
       let(:short_url_request_rejection_reason) { nil }
 
       it "should state that no reason was given" do
-        expect(mail).to have_body_content "No reason was given"
+        expect(emails.first).to have_body_content "No reason was given"
       end
     end
   end

--- a/spec/services/request_notifier_spec.rb
+++ b/spec/services/request_notifier_spec.rb
@@ -70,8 +70,8 @@ describe RequestNotifier do
         expect(recipients).to match_array(notification_recipients.map(&:email))
       end
 
-      it "should email users in batches of 25" do
-        expect(emails.count).to eq 3
+      it "should email users individually" do
+        expect(emails.count).to eq 55
       end
     end
   end


### PR DESCRIPTION
`mail-notify` allows a mailer class to simply inherit from their base mailer in order to use notify instead of normal email; this means we can keep all the same logic.

Based on https://github.com/alphagov/short-url-manager/pull/451 for the iteration over multiple recipients.

https://trello.com/c/6FJKUWIs/1794-3-short-url-manager-use-notify-instead-of-amazon-ses