### PR TITLE
[DO NOT MERGE] Disable short-url-manager cron job for migration

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,6 +6,6 @@ job_type :rake, "cd :path && govuk_setenv short-url-manager bundle exec rake :ta
 
 set :output, error: "log/cron.error.log", standard: "log/cron.log"
 
-every :day, at: "4am" do
-  rake "organisations:import"
-end
+# every :day, at: "4am" do
+#   rake "organisations:import"
+# end


### PR DESCRIPTION
* Disables cron job which triggers the `organisations:import` rake task.

* These changes will automatically update the `deploy` user crontab when the application is deployed using Jenkins.

* `organisations:import` rake task runs nightly at 4AM and imports a list of organisations from `/government/organisations/` API.

* Note: this cron job is configured using the `whenever` gem and **not** Puppet.