### PR TITLE
Upgrade Gems Mongo & Mongoid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "rails", "~> 5.2"
 gem "sass-rails", "~> 6.0"
 
-gem "mongoid", "6.2.1"
+gem "mongoid", "6.3.0"
 gem "mongoid_rails_migrations", git: "https://github.com/alphagov/mongoid_rails_migrations", branch: "avoid-calling-bundler-require-in-library-code-v1.1.0-plus-mongoid-v5-fix"
 
 # Use Uglifier as compressor for JavaScript assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    bson (4.2.2)
+    bson (4.3.0)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.32.1)
@@ -176,11 +176,11 @@ GEM
     minitest (5.14.0)
     mlanett-redis-lock (0.2.7)
       redis
-    mongo (2.4.3)
-      bson (>= 4.2.1, < 5.0.0)
-    mongoid (6.2.1)
+    mongo (2.5.0)
+      bson (>= 4.3.0, < 5.0.0)
+    mongoid (6.3.0)
       activemodel (~> 5.1)
-      mongo (>= 2.4.1, < 3.0.0)
+      mongo (>= 2.5.0, < 3.0.0)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -404,7 +404,7 @@ DEPENDENCIES
   gretel (= 3.0.9)
   mail-notify
   mlanett-redis-lock (= 0.2.7)
-  mongoid (= 6.2.1)
+  mongoid (= 6.3.0)
   mongoid_rails_migrations!
   plek
   pry


### PR DESCRIPTION
RE GOVUK are in the process of migrating Short URL Manager from Carrenza
to AWS. As part of this process we are going to switch from using a
self hosted Mongo instance to AWS DocumentDB. DocumentDB is running
the equivalent of MongoDB 3.6.0 (a higher version than we currently have on our server).
This means that the following gems need to be updated accordingly:
mongoid to 6.3.0
mongo to  2.5.0

Mongo has now been upgraded to 2.6.12 (from 2.4.9) so this update should not cause
any errors. Please see the Ruby/Mongo driver compatibility chart for more
information:
https://docs.mongodb.com/ruby-driver/master/reference/driver-compatibility/