### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     minitest (5.14.2)
     mlanett-redis-lock (0.2.7)
       redis
-    mongo (2.12.2)
+    mongo (2.13.0)
       bson (>= 4.8.2, < 5.0.0)
     mongoid (7.1.2)
       activemodel (>= 5.1, < 6.1)
@@ -355,7 +355,7 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@ module ApplicationHelper
     options = {}
     options[:class] = "active" if active
 
-    tag.li nil, options do
+    tag.li nil, **options do
       active ? title : link_to(title, path)
     end
   end


### PR DESCRIPTION
These are the changes necessary to upgrade to Ruby 2.7.1

As there is a script to update all app Ruby versions at once, leaving the version as 2.6.6

One deprecation warning remaining, coming from the Mongoid gem, specifically this line https://github.com/mongodb/mongoid/blob/d49ed95569d68505fa6fe2041c7270540cb83fc3/lib/mongoid/errors/mongoid_error.rb#L51