### PR TITLE
Improve healthchecks in preparation for CD

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,10 @@ Rails.application.routes.draw do
   end
   get "list_short_urls" => "short_url_requests#list_short_urls"
 
-  get "/healthcheck" => proc { [200, {}, %w[OK]] }
+  get "/healthcheck", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::Mongoid,
+    GovukHealthcheck::SidekiqRedis,
+  )
 
   if Rails.env.development?
     get "/styleguide" => "govuk_admin_template/style_guide#index"

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,9 +1,23 @@
 require "rails_helper"
 
-describe "the healthcheck page" do
-  it "should return success" do
+RSpec.describe "healthcheck path", type: :request do
+  before do
     get "/healthcheck"
+  end
 
-    expect(response.status).to eq(200)
+  it "returns a 200 HTTP status" do
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "includes a database_connectivity in the response body" do
+    json = JSON.parse(response.body)
+
+    expect(json["checks"]).to include("database_connectivity")
+  end
+
+  it "includes a redis_connectivity in the response body" do
+    json = JSON.parse(response.body)
+
+    expect(json["checks"]).to include("redis_connectivity")
   end
 end


### PR DESCRIPTION
Add healthchecks to check mongodb and SidekiqRedis to fulfil criteria
for continuous deployment.

Co-authored-by: Edward Kerry <edward.kerry@digital.cabinet-office.gov.uk>