### PR TITLE
Add pull request template warning of CD

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


### PR DESCRIPTION
Add a template to warn the user before merging that this app is
continuously deployed.

Co-authored-by: Edward Kerry 
<edward.kerry@digital.cabinet-office.gov.uk>