### PR TITLE
Rescue exception

### DIFF
--- a/app/services/request_notifier.rb
+++ b/app/services/request_notifier.rb
@@ -13,6 +13,11 @@ class RequestNotifier
       .map do |recipient_group|
         mailer.send(event, short_url_request, recipient_group)
       end
+  rescue Notifications::Client::BadRequestError => e
+    # in production we care about all errors
+    # in staging and integration the team-only error is unrecoverable when running asynchronously
+    # (team-only error is unrecoverable in production too, but almost certainly impossible)
+    raise if ENV["SENTRY_CURRENT_ENV"] !~ /integration|staging/ || e.message !~ /team-only API key/
   end
 
   def self.recipients_for(event_category, short_url_request)

--- a/spec/services/request_notifier_spec.rb
+++ b/spec/services/request_notifier_spec.rb
@@ -42,6 +42,19 @@ describe RequestNotifier do
 
     let(:emails) { described_class.email(:short_url_requested, short_url_request) }
 
+    context "exception testing" do
+      it "does not raise exception in integration" do
+        ENV["SENTRY_CURRENT_ENV"] = "integration"
+        expect { RequestNotifier.email(:short_url_requested, short_url_request) }.not_to raise_error(Notifications::Client::BadRequestError)
+      end
+
+      it "raises exception in production" do
+        ENV["SENTRY_CURRENT_ENV"] = "production"
+        allow(RequestNotifier).to receive(:email).with(:short_url_requested, short_url_request) { raise }
+        expect { RequestNotifier.email(:short_url_requested, short_url_request) }.to raise_error
+      end
+    end
+
     it "should send from noreply+short-url-manager@digital.cabinet-office.gov.uk" do
       expect(emails.first.from).to be == ["noreply+short-url-manager@digital.cabinet-office.gov.uk"]
     end


### PR DESCRIPTION
https://trello.com/c/6a9IvIGQ/2384-fix-notificationsclientbadrequesterror-in-short-url-manager

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
