### PR TITLE
Fix Brakeman SQL Injection warning

### DIFF
--- a/app/services/organisation_importer.rb
+++ b/app/services/organisation_importer.rb
@@ -10,7 +10,7 @@ class OrganisationImporter
   end
 
   def perform!
-    Redis.current.lock("short_url_manager:#{Rails.env}:organisation_importer_lock", life: 2.hours) do
+    Redis.current.lock("short_url_manager:organisation_importer_lock", life: 2.hours) do
       organisations_data = get_organisations_data
       Organisation.destroy_all
       organisations_data.each do |attrs|


### PR DESCRIPTION
We currently get a warning from Brakeman for possible SQL injection from the organisations importer's redis-lock that is blocking other PRs from being merged.

This was added in https://github.com/alphagov/short-url-manager/pull/8 but appears to now be unnecessary as the Rails environment is always `production` in non-test and non-CI environments anyway and each environment has it's own Redis instance.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️