### PR TITLE
Change the allowed domains for redirects

### DIFF
--- a/app/models/concerns/short_url_validations.rb
+++ b/app/models/concerns/short_url_validations.rb
@@ -8,14 +8,14 @@ module ShortUrlValidations
   end
 
   def to_path_is_valid
-    unless to_path.blank? || to_path =~ /\A\// || govuk_subdomain_url?(to_path)
-      errors.add(:to_path, 'must be a relative path (eg. "/hmrc/tax-returns") or a gov.uk redirect URL (eg. "https://my-title.service.gov.uk/an-optional-path")')
+    unless to_path.blank? || to_path =~ /\A\// || allowed_government_absolute_url?(to_path)
+      errors.add(:to_path, 'must be a relative path (eg. "/hmrc/tax-returns") or a government URL (eg. *.gov.uk, *.judiciary.uk, *.nhs.uk, *.ukri.org)')
     end
   end
 
-  def govuk_subdomain_url?(path)
+  def allowed_government_absolute_url?(path)
     uri = URI.parse(path)
-    uri.host =~ /\A([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[A-Za-z0-9])?\.)*gov\.uk\z/i && uri.scheme == "https"
+    uri.scheme == "https" && uri.host.end_with?(".gov.uk", ".judiciary.uk", ".nhs.uk", ".ukri.org") && uri.host != "www.gov.uk"
   rescue StandardError
     false
   end

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -18,6 +18,7 @@
       <ul class="help-block">
         <li>Internal gov.uk links, eg. <strong>/government/publications/what-hmrc-does-to-prevent-tax-evasion</strong></li>
         <li>External gov.uk subdomain links, eg. <strong>https://my-title.external.gov.uk/an-optional-path</strong></li>
+        <li>External government subdomain links, eg. <strong>*.judiciary.uk, *.nhs.uk, *.ukri.org</strong></li>
       </ul>
     </div>
 

--- a/spec/support/shared_examples_for_short_url_validations.rb
+++ b/spec/support/shared_examples_for_short_url_validations.rb
@@ -20,16 +20,28 @@ shared_examples_for "ShortUrlValidations" do |klass|
     end
 
     it "may be a gov.uk subdomain URL" do
-      expect(build(klass, to_path: "https://my.service.gov.uk")).to be_valid
       expect(build(klass, to_path: "https://my.service.gov.uk/path")).to be_valid
     end
 
-    it "must be either a relative path or a gov.uk campaign URL" do
-      expect(build(klass, to_path: "https://www.somewhere.com/a-path")).to_not be_valid
-      expect(build(klass, to_path: "https://.campaign.gov.uk")).to_not be_valid
-      expect(build(klass, to_path: "http://my.campaign.gov.uk")).to_not be_valid
-      expect(build(klass, to_path: "http://my.campaign.gov.uk/path")).to_not be_valid
-      expect(build(klass, to_path: "ftp://my.campaign.gov.uk")).to_not be_valid
+    it "may not be a non HTTPS URL" do
+      expect(build(klass, to_path: "http://my.service.gov.uk/path")).to_not be_valid
+      expect(build(klass, to_path: "ftp://my.service.gov.uk")).to_not be_valid
+    end
+
+    it "may not be a www.gov.uk subdomain URL" do
+      expect(build(klass, to_path: "https://www.gov.uk/path")).to_not be_valid
+    end
+
+    it "may be an nhs.uk subdomain URL" do
+      expect(build(klass, to_path: "https://www.nhs.uk/path")).to be_valid
+    end
+
+    it "may be a judiciary.uk subdomain URL" do
+      expect(build(klass, to_path: "https://www.judiciary.uk/path")).to be_valid
+    end
+
+    it "may be a ukri.org subdomain URL" do
+      expect(build(klass, to_path: "https://www.ukri.org/path")).to be_valid
     end
   end
 end


### PR DESCRIPTION
This is in order to bring our allowed redirect domains in line with what
is permitted (in the publishing api)[https://github.com/alphagov/publishing-api/blob/1e96c7ef416b641706c14290d539bb1d36a93fff/app/validators/routes_and_redirects_validator.rb#L168-L170]

Trello - https://trello.com/c/OE0mGWzN/1630-create-pharmacy-collect-short-urls-for-13-september

This can't be merged before [the matching pr in govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas/pull/1072) has been deployed because this would lead to some confusing error messages and data inconsistency. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
