### PR TITLE
Add short url deletion feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development, :test do
   gem "database_cleaner"
   gem "factory_bot_rails"
   gem "govuk-content-schema-test-helpers"
+  gem "listen"
   gem "rails-controller-testing"
   gem "rspec-rails"
   gem "rubocop-govuk"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,9 @@ GEM
     jwt (2.2.3)
     kgio (2.11.4)
     link_header (0.0.8)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
@@ -277,6 +280,9 @@ GEM
     rainbow (3.0.0)
     raindrops (0.19.2)
     rake (13.0.6)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     redis (4.1.4)
     redis-namespace (1.8.0)
       redis (>= 3.0.4)
@@ -425,6 +431,7 @@ DEPENDENCIES
   govuk_app_config
   govuk_sidekiq
   gretel
+  listen
   mail-notify
   mlanett-redis-lock
   mongoid

--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -1,7 +1,7 @@
 class ShortUrlRequestsController < ApplicationController
   before_action :authorise_as_short_url_requester!, only: %i[new create]
-  before_action :authorise_as_short_url_manager!, only: %i[index show accept new_rejection reject list_short_urls edit update destroy]
-  before_action :get_short_url_request, only: %i[edit update show accept new_rejection reject destroy]
+  before_action :authorise_as_short_url_manager!, only: %i[index show accept new_rejection reject list_short_urls edit update destroy remove]
+  before_action :get_short_url_request, only: %i[edit update show accept new_rejection reject destroy remove]
 
   def index
     @short_url_requests = ShortUrlRequest.pending.order_by([:created_at, "desc"]).paginate(page: params[:page], per_page: 40)
@@ -67,6 +67,8 @@ class ShortUrlRequestsController < ApplicationController
       failure: -> { render "edit" },
     )
   end
+
+  def remove; end
 
   def destroy
     Commands::ShortUrlRequests::Destroy.new(get_short_url_request).call(

--- a/app/lib/commands/short_url_requests/destroy.rb
+++ b/app/lib/commands/short_url_requests/destroy.rb
@@ -1,0 +1,17 @@
+class Commands::ShortUrlRequests::Destroy
+  def initialize(short_url)
+    @short_url = short_url
+  end
+
+  def call(success:, failure:)
+    if short_url.destroy
+      success.call
+    else
+      failure.call
+    end
+  end
+
+private
+
+  attr_reader :short_url
+end

--- a/app/models/short_url_request.rb
+++ b/app/models/short_url_request.rb
@@ -17,7 +17,7 @@ class ShortUrlRequest
   field :rejection_reason, type: String
 
   belongs_to :requester, class_name: "User", optional: true
-  has_one :redirect
+  has_one :redirect, dependent: :destroy
 
   validates :state, :reason, :contact_email, :organisation_slug, :organisation_title, presence: true
   validates :state, inclusion: { in: %w[pending accepted rejected superseded] }, allow_blank: true

--- a/app/views/short_url_requests/remove.html.erb
+++ b/app/views/short_url_requests/remove.html.erb
@@ -1,0 +1,13 @@
+<% breadcrumb :remove_short_url_request, @short_url_request %>
+
+<h1>Delete URL redirect or Short URL <%= @short_url_request.from_path %></h1>
+
+<%= form_for(@short_url_request, html: { method: :delete }) do |f| %>
+  <%= render_errors_for @short_url_request, leading_message: "Your submission failed for the following reasons:" %>
+  <fieldset>
+    <div class="form-group">
+      <%= f.submit "Delete", class: 'btn btn-danger' %>
+      <%= link_to "Cancel", short_url_request_path(@short_url_request), class: "btn btn-default add-left-margin" %>
+    </div>
+  </fieldset>
+<%- end -%>

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -43,3 +43,4 @@
   <%= link_to "Reject", new_rejection_short_url_request_path(@short_url_request), class: "btn btn-danger add-right-margin" %>
 <% end %>
 <%= link_to "Edit", edit_short_url_request_path, class: "btn btn-default" %>
+<%= link_to "Delete", remove_short_url_request_path, class: "btn btn-danger" %>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -27,6 +27,11 @@ crumb :edit_short_url_request do |short_url_request|
   parent :short_url_request, short_url_request
 end
 
+crumb :remove_short_url_request do |short_url_request|
+  link "Remove short URL", remove_short_url_request_path(short_url_request)
+  parent :short_url_request, short_url_request
+end
+
 crumb :reject_short_url_request do |short_url_request|
   link "Reject URL redirect or short URL", reject_short_url_request_path(short_url_request)
   parent :short_url_request, short_url_request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     member do
       post "accept" => "short_url_requests#accept"
       get "new_rejection" => "short_url_requests#new_rejection"
+      get "remove" => "short_url_requests#remove"
       post "reject" => "short_url_requests#reject"
     end
   end

--- a/lib/tasks/redirect.rake
+++ b/lib/tasks/redirect.rake
@@ -1,7 +1,0 @@
-namespace :redirect do
-  desc "Destroy and unpublish a redirect."
-  task :destroy, %i[content_id] => :environment do |_, args|
-    content_id = args.fetch(:content_id)
-    Redirect.find_by!(content_id: content_id).destroy!
-  end
-end

--- a/spec/controllers/short_url_requests_controller_spec.rb
+++ b/spec/controllers/short_url_requests_controller_spec.rb
@@ -6,6 +6,14 @@ describe ShortUrlRequestsController do
   before { login_as user }
 
   describe "access control" do
+    context "with a user without any permissions" do
+      let(:user) { create(:user) }
+
+      specify do
+        expect_not_authorised(:post, :destroy, id: "required-param")
+      end
+    end
+
     context "with a user without request_short_urls permission" do
       let(:user) { create(:short_url_manager) }
 
@@ -24,6 +32,7 @@ describe ShortUrlRequestsController do
         expect_not_authorised(:post, :accept, id: "required-param")
         expect_not_authorised(:get, :new_rejection, id: "required-param")
         expect_not_authorised(:post, :reject, id: "required-param")
+        expect_not_authorised(:post, :destroy, id: "required-param")
       end
     end
   end
@@ -338,6 +347,37 @@ describe ShortUrlRequestsController do
 
         short_url_request.reload
         expect(short_url_request.from_path).to eql("/original")
+      end
+    end
+  end
+
+  describe "#destroy" do
+    let!(:organisation) { create(:organisation) }
+    let!(:short_url_request) { create(:short_url_request, :accepted, from_path: "/original") }
+    let!(:short_url_request_2) { create(:short_url_request, :accepted, from_path: "/other-original") }
+    context "with a valid short url" do
+      it "destroys and unpublishes the short-url" do
+        unpublish_req = stub_any_publishing_api_call
+          .with(body: '{"type":"gone"}')
+        stub_any_publishing_api_call
+        put :destroy, params: { id: short_url_request.id }
+        expect(response).to redirect_to(short_url_requests_path)
+        expect(ShortUrlRequest.all).to eq([short_url_request_2])
+        expect(Redirect.all).to eq([short_url_request_2.redirect])
+        assert_requested(unpublish_req)
+      end
+    end
+
+    context "with an invalid short url" do
+      it "returns a 404" do
+        unpublish_req = stub_any_publishing_api_call
+          .with(body: '{"type":"gone"}')
+        stub_any_publishing_api_call
+        put :destroy, params: { id: 123 }
+        expect(response).to have_http_status(:not_found)
+        expect(ShortUrlRequest.count).to eq(2)
+        expect(Redirect.count).to eq(2)
+        assert_not_requested(unpublish_req)
       end
     end
   end

--- a/spec/controllers/short_url_requests_controller_spec.rb
+++ b/spec/controllers/short_url_requests_controller_spec.rb
@@ -10,6 +10,7 @@ describe ShortUrlRequestsController do
       let(:user) { create(:user) }
 
       specify do
+        expect_not_authorised(:get, :remove, id: "required-param")
         expect_not_authorised(:post, :destroy, id: "required-param")
       end
     end
@@ -32,6 +33,7 @@ describe ShortUrlRequestsController do
         expect_not_authorised(:post, :accept, id: "required-param")
         expect_not_authorised(:get, :new_rejection, id: "required-param")
         expect_not_authorised(:post, :reject, id: "required-param")
+        expect_not_authorised(:get, :remove, id: "required-param")
         expect_not_authorised(:post, :destroy, id: "required-param")
       end
     end
@@ -347,6 +349,20 @@ describe ShortUrlRequestsController do
 
         short_url_request.reload
         expect(short_url_request.from_path).to eql("/original")
+      end
+    end
+  end
+
+  describe "#remove" do
+    let!(:organisation) { create(:organisation) }
+    let!(:short_url_request) { create(:short_url_request, :accepted, from_path: "/original") }
+    render_views
+    context "with a valid short url" do
+      it "shows a confirm deletion message for the short-url" do
+        get :remove, params: { id: short_url_request.id }
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:remove)
+        expect(response.body).to include("Delete URL redirect or Short URL /original")
       end
     end
   end

--- a/spec/lib/commands/short_url_requests/destroy_spec.rb
+++ b/spec/lib/commands/short_url_requests/destroy_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe Commands::ShortUrlRequests::Destroy do
+  let(:url_request) { create(:short_url_request, :accepted, from_path: "/deletable-url") }
+  let(:other_url_request) { create(:short_url_request, :accepted, from_path: "/undeletable-url") }
+  subject(:command) { described_class.new(url_request) }
+  let(:success) { double(:success, call: true) }
+  let(:failure) { double(:failure, call: true) }
+
+  context "with a deletable short url" do
+    it "deletes the record" do
+      command.call(success: success, failure: failure)
+      expect(ShortUrlRequest.all).to eq([other_url_request])
+    end
+
+    it "deletes the redirect" do
+      command.call(success: success, failure: failure)
+      expect(Redirect.all).to eq([other_url_request.redirect])
+    end
+
+    it "calls the success callback" do
+      command.call(success: success, failure: failure)
+      expect(success).to have_received(:call).once
+    end
+  end
+
+  context "when deletion fails" do
+    let(:undeletable_url_req) do
+      double(ShortUrlRequest, destroy: false)
+    end
+    subject(:command) { described_class.new(undeletable_url_req) }
+
+    it "does not delete the url" do
+      command.call(success: success, failure: failure)
+
+      expect(ShortUrlRequest.all).to eq([url_request, other_url_request])
+    end
+
+    it "does not delete the redirect" do
+      command.call(success: success, failure: failure)
+
+      expect(Redirect.all).to eq([url_request.redirect, other_url_request.redirect])
+    end
+
+    it "calls the failure callback" do
+      command.call(success: success, failure: failure)
+
+      expect(failure).to have_received(:call).once
+    end
+  end
+end


### PR DESCRIPTION
The app now supports deleting short-urls by users with the short-url-manager permission.

This replaces the prior process which required developers to take manual action on behalf of users to delete short url.

Co Authored By: @danacotoran 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
