### PR TITLE
Unreserve path when redirect deleted

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -42,6 +42,7 @@ private
 
   def unpublish_in_publishing_api
     GdsApi.publishing_api.unpublish(content_id, type: "gone")
+    GdsApi.publishing_api.unreserve_path(from_path, "short-url-manager")
   end
 
   def ensure_presence_of_content_id

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -110,6 +110,13 @@ describe Redirect do
       assert_publishing_api_unpublish(redirect.content_id, type: "gone")
     end
 
+    it "unreserves the path in the Publishing API" do
+      unreserve_path_request = stub_publishing_api_unreserve_path(redirect.from_path, "short-url-manager")
+      redirect.destroy!
+
+      expect(unreserve_path_request).to have_been_requested
+    end
+
     context "when unpublishing fails" do
       it "fails to destroy" do
         stub_any_publishing_api_call


### PR DESCRIPTION
Trello: https://trello.com/c/7zcunjyo
Follows on from: #653

# What's changed?
Unreserve the base path in Publishing API when a redirect is deleted.

# Why?
When a redirect is created using Short URL Manager, the ownership of that base path changes from the original publishing application to "short-url-manager" in Publishing API.

Currently, when the redirect is deleted, the unpublish type is set to "gone" rather than "redirect", but the base path is still owned by Short URL Manager, meaning that the original page cannot be republished, nor can the base path be used for a new page unless a developer brings up a rails console and manually calls the "unreserve_path" method.

Calling "unreserve_path" when the redirect is deleted removes this need for manual intervention.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
