### PR TITLE
Add optimalworkshop.com to allowlist of external domains

### DIFF
--- a/app/models/concerns/short_url_validations.rb
+++ b/app/models/concerns/short_url_validations.rb
@@ -15,7 +15,7 @@ module ShortUrlValidations
 
   def allowed_government_absolute_url?(path)
     uri = URI.parse(path)
-    uri.scheme == "https" && uri.host.end_with?(".gov.uk", ".judiciary.uk", ".nhs.uk", ".ukri.org") && uri.host != "www.gov.uk"
+    uri.scheme == "https" && uri.host.end_with?(".gov.uk", ".judiciary.uk", ".nhs.uk", ".ukri.org", "optimalworkshop.com") && uri.host != "www.gov.uk"
   rescue StandardError
     false
   end

--- a/spec/support/shared_examples_for_short_url_validations.rb
+++ b/spec/support/shared_examples_for_short_url_validations.rb
@@ -43,5 +43,9 @@ shared_examples_for "ShortUrlValidations" do |klass|
     it "may be a ukri.org subdomain URL" do
       expect(build(klass, to_path: "https://www.ukri.org/path")).to be_valid
     end
+
+    it "may be a optimalworkshop.com subdomain URL" do
+      expect(build(klass, to_path: "https://www.optimalworkshop.com/path")).to be_valid
+    end
   end
 end


### PR DESCRIPTION
The explore team is adding a recruitment banner to subsets of pages
on govuk. The banner contains a link to the online survey at the
above domain. To save us having to redeploy the frontend applications
every time the survey URL is updated we would like to set up a redirect
in short-url manager. Once we have completed this phase of testing
optimalworkshop.com will be removed from the allowlist.

Related PR https://github.com/alphagov/publishing-api/pull/2050
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
