### PR TITLE
Bump govuk_app_config to 4.6 and install sentry-sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "mongoid"
 gem "plek"
 gem "redis", require: false # Used by the Organisation importer as a locking mechanism
 gem "sassc-rails"
+gem "sentry-sidekiq"
 gem "uglifier"
 gem "whenever", require: false
 gem "will_paginate_mongoid"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,12 +126,12 @@ GEM
       jquery-rails (~> 4.3)
       plek (>= 2.1)
       rails (>= 6)
-    govuk_app_config (4.5.0)
+    govuk_app_config (4.6.0)
       logstasher (~> 2.1)
       prometheus_exporter (~> 2.0)
       puma (~> 5.6)
-      sentry-rails (~> 5.2)
-      sentry-ruby (~> 5.2)
+      sentry-rails (~> 5.3)
+      sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
       unicorn (~> 6.1)
     govuk_sidekiq (5.0.0)
@@ -165,7 +165,7 @@ GEM
     logstasher (2.1.5)
       activesupport (>= 5.2)
       request_store
-    loofah (2.17.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -335,14 +335,17 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    sentry-rails (5.2.1)
+    sentry-rails (5.3.0)
       railties (>= 5.0)
-      sentry-ruby-core (~> 5.2.1)
-    sentry-ruby (5.2.1)
+      sentry-ruby-core (~> 5.3.0)
+    sentry-ruby (5.3.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      sentry-ruby-core (= 5.2.1)
-    sentry-ruby-core (5.2.1)
+      sentry-ruby-core (= 5.3.0)
+    sentry-ruby-core (5.3.0)
       concurrent-ruby
+    sentry-sidekiq (5.3.0)
+      sentry-ruby-core (~> 5.3.0)
+      sidekiq (>= 3.0)
     sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -428,6 +431,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sassc-rails
+  sentry-sidekiq
   simplecov
   simplecov-rcov
   uglifier


### PR DESCRIPTION
Trello: https://trello.com/c/CXTgjI76/383-look-at-sidekiqjobretryskip-errors-logged-to-sentry

In order to track sidekiq errors apps that use Sidekiq need to install
sentry-sidekiq, this installs it.

Without it a warning will occur on application initialisation and
Sidekiq errors won't be tracked by Sentry.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
