### PR TITLE
Replace govuk content schema test helpers with govuk schemas gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ group :development, :test do
   gem "capybara"
   gem "database_cleaner"
   gem "factory_bot_rails"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "listen"
   gem "rails-controller-testing"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,8 +119,6 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_admin_template (6.9.2)
       bootstrap-sass (~> 3.4)
       jquery-rails (~> 4.3)
@@ -134,6 +132,8 @@ GEM
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
       unicorn (~> 6.1)
+    govuk_schemas (4.3.0)
+      json-schema (~> 2.8.0)
     govuk_sidekiq (5.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -415,9 +415,9 @@ DEPENDENCIES
   factory_bot_rails
   gds-api-adapters
   gds-sso
-  govuk-content-schema-test-helpers
   govuk_admin_template
   govuk_app_config
+  govuk_schemas
   govuk_sidekiq
   gretel
   listen

--- a/spec/presenters/publishing_api_presenter_spec.rb
+++ b/spec/presenters/publishing_api_presenter_spec.rb
@@ -27,6 +27,6 @@ RSpec.describe Presenters::PublishingAPI do
 
   it "validates successfully against the content schema" do
     presented = described_class.present(redirect)
-    expect(presented).to be_valid_against_schema("redirect")
+    expect(presented).to be_valid_against_publisher_schema("redirect")
   end
 end

--- a/spec/support/gov_content_schemas.rb
+++ b/spec/support/gov_content_schemas.rb
@@ -1,9 +1,3 @@
-require "govuk-content-schema-test-helpers"
-require "govuk-content-schema-test-helpers/rspec_matchers"
+require "govuk_schemas/rspec_matchers"
 
-RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers
-
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "publisher_v2"
-  config.project_root = Rails.root
-end
+RSpec.configuration.include GovukSchemas::RSpecMatchers


### PR DESCRIPTION
## Description 

This PR replaces the govuk-content-schema-test-helpers gem with the govuk_schemas gem to validate content item schemas.

[govuk-content-schema-test-helpers] has been archived and there is a concern that it no longer receives any security updates. The advice in the govuk-content-schema-test-helpers repo is to replace it with the govuk_schemas gem.

[govuk-content-schema-test-helpers]: https://github.com/alphagov/govuk-content-schema-test-helpers

## Trello card

https://trello.com/c/Q9O5rXnz/550-stop-using-the-deprecated-govuk-content-schema-test-helpers-gem
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
