### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/app/services/organisation_importer.rb
+++ b/app/services/organisation_importer.rb
@@ -10,7 +10,7 @@ class OrganisationImporter
   end
 
   def perform!
-    Redis.new.lock("short_url_manager:organisation_importer_lock", life: 2.hours) do
+    Redis.current.lock("short_url_manager:organisation_importer_lock", life: 2.hours) do
       organisations_data = get_organisations_data
       Organisation.destroy_all
       organisations_data.each do |attrs|


### PR DESCRIPTION
Redis.current will be deprecated in Redis 5.0.

As Redis.current ultimately calls Redis.new we can migrate this method now to pave the way for future upgrades.

From Redis changelog from [5.0][1]:

‘Removed Redis.current. You shouldn't assume there is a single global Redis connection, use a connection pool instead, and libaries using Redis should accept a Redis instance (or connection pool) as a config. E.g. MyLibrary.redis = Redis.new(…).’

[Redis.current][2] just calls Redis.new so should just be able to swap methods.

[trello](https://trello.com/c/oGFWhrCO/1551-migrate-away-from-deprecated-redis-method)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
