### PR TITLE
Switch from deprecated `Plek.current` to `Plek.new`.

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,6 +1,6 @@
 module UrlHelper
   def govuk_url_for(path)
-    (Plek.current.website_uri + path).to_s
+    (Plek.new.website_uri + path).to_s
   end
 
   def short_url_manger_url_for(path)

--- a/app/services/organisation_importer.rb
+++ b/app/services/organisation_importer.rb
@@ -6,7 +6,7 @@ class OrganisationImporter
   attr_reader :api_url_base
 
   def initialize(api_url_base = nil)
-    @api_url_base = api_url_base || Plek.current.website_root
+    @api_url_base = api_url_base || Plek.new.website_root
   end
 
   def perform!


### PR DESCRIPTION
This just gets rid of the deprecation warnings in the logs. No functional change.