### PR TITLE
Bump Plek to version 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,10 +108,10 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (2.6.0)
+    faraday (2.7.1)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.1)
+    faraday-net_http (3.0.2)
     ffi (1.15.5)
     gds-api-adapters (84.0.0)
       addressable
@@ -119,11 +119,11 @@ GEM
       null_logger
       plek (>= 1.9.0)
       rest-client (~> 2.0)
-    gds-sso (17.1.0)
+    gds-sso (17.1.1)
       oauth2 (~> 2.0)
       omniauth (~> 2.1)
       omniauth-oauth2 (~> 1.8)
-      plek (~> 4.0)
+      plek (>= 4, < 6)
       rails (>= 6)
       warden (~> 1.2)
       warden-oauth2 (~> 0.0.1)
@@ -134,9 +134,9 @@ GEM
       jquery-rails (~> 4.3)
       plek (>= 2.1)
       rails (>= 6)
-    govuk_app_config (4.10.1)
+    govuk_app_config (4.11.0)
       logstasher (~> 2.1)
-      plek (~> 4)
+      plek (>= 4, < 6)
       prometheus_exporter (~> 2.0)
       puma (>= 5.6, < 7.0)
       rack-proxy (~> 0.7)
@@ -248,15 +248,15 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    plek (4.1.0)
-    prometheus_exporter (2.0.3)
+    plek (5.0.0)
+    prometheus_exporter (2.0.5)
       webrick
     public_suffix (5.0.0)
     puma (6.0.0)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
-    rack-protection (3.0.2)
+    rack-protection (3.0.3)
       rack
     rack-proxy (0.7.4)
       rack
@@ -435,7 +435,7 @@ GEM
       will_paginate (~> 3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.3)
+    zeitwerk (2.6.6)
 
 PLATFORMS
   aarch64-linux

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,6 +1,6 @@
 module UrlHelper
   def govuk_url_for(path)
-    (Plek.new.website_uri + path).to_s
+    (Plek.website_root + path).to_s
   end
 
   def short_url_manger_url_for(path)

--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -4,6 +4,6 @@ module UrlHelper
   end
 
   def short_url_manger_url_for(path)
-    (Plek.new.external_url_for("short-url-manager") + path).to_s
+    (Plek.external_url_for("short-url-manager") + path).to_s
   end
 end

--- a/app/services/organisation_importer.rb
+++ b/app/services/organisation_importer.rb
@@ -6,7 +6,7 @@ class OrganisationImporter
   attr_reader :api_url_base
 
   def initialize(api_url_base = nil)
-    @api_url_base = api_url_base || Plek.new.website_root
+    @api_url_base = api_url_base || Plek.website_root
   end
 
   def perform!

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
 <% content_for :app_title, "Short URL manager" %>
 
 <% content_for :navbar_right do %>
-  Hello, <%= link_to current_user.name, Plek.new.external_url_for('signon') %>
+  Hello, <%= link_to current_user.name, Plek.external_url_for('signon') %>
   &bull; <%= link_to 'Sign out', gds_sign_out_path %>
 <% end %>
 

--- a/spec/services/request_notifier_spec.rb
+++ b/spec/services/request_notifier_spec.rb
@@ -77,7 +77,7 @@ describe RequestNotifier do
     end
 
     it "includes a link to the short url request" do
-      expect(emails.first).to have_body_content "You can respond to this request here: #{Plek.new.external_url_for('short-url-manager') + short_url_request_path(short_url_request)}"
+      expect(emails.first).to have_body_content "You can respond to this request here: #{Plek.external_url_for('short-url-manager') + short_url_request_path(short_url_request)}"
     end
 
     context "with many users with permissions to receive notifications" do


### PR DESCRIPTION
Short URL Manager is one of the few repos that needs amends for https://github.com/alphagov/plek/pull/93#issuecomment-1319922899. So I've done the update manually and updated related gems.

More info in the commits

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
