### PR TITLE
Remove Mailer from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "govuk_admin_template"
 gem "govuk_app_config"
 gem "govuk_sidekiq"
 gem "gretel"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mail-notify"
 gem "mlanett-redis-lock" # Used by the Organisation importer as a locking mechanism
 gem "mongoid"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,6 @@ DEPENDENCIES
   govuk_sidekiq
   gretel
   listen
-  mail (~> 2.8.0)
   mail-notify
   mlanett-redis-lock
   mongoid


### PR DESCRIPTION
Previously, there was an issue with the mailer gem in release 2.8.0 mikel/mail#1489.

To circumvent this we added it to the Gemfile and pinned it on the 2.7.0 release. Since this has been fixed we can remove it as a direct dependency.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
