### PR TITLE
Update allowed hosts / allow moneyhelper org.uk

### DIFF
--- a/app/models/concerns/short_url_validations.rb
+++ b/app/models/concerns/short_url_validations.rb
@@ -1,6 +1,19 @@
 module ShortUrlValidations
   extend ActiveSupport::Concern
 
+  # Ideally this should be kept up to date with the corresponding list in the publishing API
+  # https://github.com/alphagov/publishing-api/blob/main/app/validators/routes_and_redirects_validator.rb#L2-L10
+  EXTERNAL_HOST_ALLOW_LIST = %w[
+    .caa.co.uk
+    .gov.uk
+    .judiciary.uk
+    .moneyhelper.org.uk
+    .nationalhighways.co.uk
+    .nhs.uk
+    .police.uk
+    .ukri.org
+  ].freeze
+
   included do
     validates :from_path, :to_path, presence: true
     validates :from_path, format: { with: /\A\//, message: 'must be specified as a relative path (eg. "/hmrc/tax-returns")' }, allow_blank: true
@@ -9,14 +22,18 @@ module ShortUrlValidations
 
   def to_path_is_valid
     unless to_path.blank? || to_path =~ /\A\// || allowed_government_absolute_url?(to_path)
-      errors.add(:to_path, 'must be a relative path (eg. "/hmrc/tax-returns") or a government URL (eg. *.gov.uk, *.judiciary.uk, *.nhs.uk, *.ukri.org)')
+      errors.add(:to_path, "must be a relative path (eg. /hmrc/tax-returns) or a government URL (eg. #{ShortUrlValidations.allow_host_display_list})")
     end
   end
 
   def allowed_government_absolute_url?(path)
     uri = URI.parse(path)
-    uri.scheme == "https" && uri.host.end_with?(".gov.uk", ".judiciary.uk", ".nhs.uk", ".ukri.org") && uri.host != "www.gov.uk"
+    uri.scheme == "https" && uri.host.end_with?(*EXTERNAL_HOST_ALLOW_LIST) && uri.host != "www.gov.uk"
   rescue StandardError
     false
+  end
+
+  def self.allow_host_display_list
+    EXTERNAL_HOST_ALLOW_LIST.map { |host| "*#{host}" }.join(", ")
   end
 end

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -18,7 +18,7 @@
       <ul class="help-block">
         <li>Internal gov.uk links, eg. <strong>/government/publications/what-hmrc-does-to-prevent-tax-evasion</strong></li>
         <li>External gov.uk subdomain links, eg. <strong>https://my-title.external.gov.uk/an-optional-path</strong></li>
-        <li>External government subdomain links, eg. <strong>*.judiciary.uk, *.nhs.uk, *.ukri.org</strong></li>
+        <li>External government subdomain links, eg. <strong><%= ShortUrlValidations.allow_host_display_list %></strong></li>
       </ul>
     </div>
 

--- a/spec/support/shared_examples_for_short_url_validations.rb
+++ b/spec/support/shared_examples_for_short_url_validations.rb
@@ -32,12 +32,28 @@ shared_examples_for "ShortUrlValidations" do |klass|
       expect(build(klass, to_path: "https://www.gov.uk/path")).to_not be_valid
     end
 
+    it "may be a caa.co.uk subdomain URL" do
+      expect(build(klass, to_path: "https://www.caa.co.uk/path")).to be_valid
+    end
+
     it "may be a judiciary.uk subdomain URL" do
       expect(build(klass, to_path: "https://www.judiciary.uk/path")).to be_valid
     end
 
+    it "may be a moneyhelper.org.uk subdomain URL" do
+      expect(build(klass, to_path: "https://adviser.moneyhelper.org.uk/path")).to be_valid
+    end
+
+    it "may be an nationalhighways.co.uk subdomain URL" do
+      expect(build(klass, to_path: "https://www.nationalhighways.co.uk/path")).to be_valid
+    end
+
     it "may be an nhs.uk subdomain URL" do
       expect(build(klass, to_path: "https://www.nhs.uk/path")).to be_valid
+    end
+
+    it "may be a police.uk subdomain URL" do
+      expect(build(klass, to_path: "https://www.police.uk/path")).to be_valid
     end
 
     it "may be a ukri.org subdomain URL" do

--- a/spec/support/shared_examples_for_short_url_validations.rb
+++ b/spec/support/shared_examples_for_short_url_validations.rb
@@ -32,12 +32,12 @@ shared_examples_for "ShortUrlValidations" do |klass|
       expect(build(klass, to_path: "https://www.gov.uk/path")).to_not be_valid
     end
 
-    it "may be an nhs.uk subdomain URL" do
-      expect(build(klass, to_path: "https://www.nhs.uk/path")).to be_valid
-    end
-
     it "may be a judiciary.uk subdomain URL" do
       expect(build(klass, to_path: "https://www.judiciary.uk/path")).to be_valid
+    end
+
+    it "may be an nhs.uk subdomain URL" do
+      expect(build(klass, to_path: "https://www.nhs.uk/path")).to be_valid
     end
 
     it "may be a ukri.org subdomain URL" do


### PR DESCRIPTION
- update hosts list to match equivalent list in publishing API
- add moneyhelper.org.uk as per https://govuk.zendesk.com/agent/tickets/5516679

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
