### PR TITLE
Add Google Tag Manager snippet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_admin_template"
 gem "govuk_app_config"
+
+gem "govuk_publishing_components"
 gem "govuk_sidekiq"
 gem "gretel"
 gem "mail-notify"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,17 @@ GEM
       sentry-rails (~> 5.3)
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
+    govuk_personalisation (0.15.0)
+      plek (>= 1.9.0)
+      rails (>= 6, < 8)
+    govuk_publishing_components (35.21.2)
+      govuk_app_config
+      govuk_personalisation (>= 0.7.0)
+      kramdown
+      plek
+      rails (>= 6)
+      rouge
+      sprockets (>= 3)
     govuk_schemas (4.7.0)
       json-schema (>= 2.8, < 4.2)
     govuk_sidekiq (7.1.3)
@@ -180,6 +191,8 @@ GEM
     json-schema (4.1.1)
       addressable (>= 2.8)
     jwt (2.7.1)
+    kramdown (2.4.0)
+      rexml
     language_server-protocol (3.17.0.3)
     link_header (0.0.8)
     listen (3.8.0)
@@ -521,6 +534,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.6)
+    rouge (4.2.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -663,6 +677,7 @@ DEPENDENCIES
   gds-sso
   govuk_admin_template
   govuk_app_config
+  govuk_publishing_components
   govuk_schemas
   govuk_sidekiq
   gretel

--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,9 @@
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+  <% content_for :head do %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
+    } %>
+  <% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,5 @@
+<% render "layouts/google_tag_manager" %>
+
 <% content_for :page_title, "GOV.UK - Short URL manager" %>
 
 <% content_for :head do %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,4 +53,10 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Using a sass css compressor causes a scss file to be processed twice
+  # (once to build, once to compress) which breaks the usage of "unquote"
+  # to use CSS that has same function names as SCSS such as max.
+  # https://github.com/alphagov/govuk-frontend/issues/1350
+  config.assets.css_compressor = nil
 end


### PR DESCRIPTION
Google Tag Manager (GTM) can be included on all pages of the app by configuring the following environment variables:

- GOOGLE_TAG_MANAGER_ID
- GOOGLE_TAG_MANAGER_AUTH
- GOOGLE_TAG_MANAGER_PREVIEW

All three variables are optional.

If none are set, GTM will not be included on the page.

If only GOOGLE_TAG_MANAGER_ID is set, the default environment of the GTM container will be used.

If GOOGLE_TAG_MANAGER_AUTH and GOOGLE_TAG_MANAGER_PREVIEW are set, the specified GTM container environment will be used. This is used for managing the rollout of changes to integration so they can be tested before rolling out to production.

Trello card: https://trello.com/c/Wcuq3R1S/2167-add-ga4-page-view-tracking-to-apps-that-we-own
