### PR TITLE
Sass error while building image upon deployment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,13 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
+  # Using a sass css compressor causes a scss file to be processed twice
+  # (once to build, once to compress) which breaks the usage of "unquote"
+  # to use CSS that has same function names as SCSS such as max.
+  # https://github.com/alphagov/govuk-frontend/issues/1350
+  config.assets.css_compressor = nil
+  config.sass.style = :compressed
+
   # Generate digests for assets URLs.
   config.assets.digest = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -59,4 +59,5 @@ Rails.application.configure do
   # to use CSS that has same function names as SCSS such as max.
   # https://github.com/alphagov/govuk-frontend/issues/1350
   config.assets.css_compressor = nil
+  config.sass.style = :compressed
 end


### PR DESCRIPTION
We were getting the error:
```SassC::SyntaxError: Internal Error: Incompatible units: 'px' and 'rem'.```
when images are being built on the Deploy CI action.

Attempting to fix via adding different asset compression also to production.rb

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
