### PR TITLE
Migrate to dart sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+/public/assets
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "7.1.3"
 
 gem "bootsnap", require: false
+gem "dartsass-rails"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_admin_template"
@@ -16,7 +17,6 @@ gem "mlanett-redis-lock" # Used by the Organisation importer as a locking mechan
 gem "mongoid"
 gem "plek"
 gem "redis", require: false # Used by the Organisation importer as a locking mechanism
-gem "sassc-rails"
 gem "sentry-sidekiq"
 gem "uglifier"
 gem "whenever", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dartsass-rails (0.5.0)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     database_cleaner-core (2.0.1)
     database_cleaner-mongoid (2.0.1)
       database_cleaner-core (~> 2.0.0)
@@ -618,14 +621,17 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    sass-embedded (1.70.0)
+      google-protobuf (~> 3.25)
+      rake (>= 13.0.0)
+    sass-embedded (1.70.0-aarch64-linux-gnu)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-arm64-darwin)
+      google-protobuf (~> 3.25)
+    sass-embedded (1.70.0-x86_64-linux-gnu)
+      google-protobuf (~> 3.25)
     sassc (2.4.0)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     sentry-rails (5.16.1)
       railties (>= 5.0)
       sentry-ruby (~> 5.16.1)
@@ -659,7 +665,6 @@ GEM
     statsd-ruby (1.5.0)
     stringio (3.1.0)
     thor (1.3.0)
-    tilt (2.0.11)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -700,6 +705,7 @@ DEPENDENCIES
   brakeman
   byebug
   capybara
+  dartsass-rails
   database_cleaner-mongoid
   factory_bot_rails
   gds-api-adapters
@@ -720,7 +726,6 @@ DEPENDENCIES
   redis
   rspec-rails
   rubocop-govuk
-  sassc-rails
   sentry-sidekiq
   simplecov
   simplecov-rcov

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,3 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
+//= link_tree ../builds
 

--- a/app/lib/tasks/assets.rake
+++ b/app/lib/tasks/assets.rake
@@ -1,0 +1,1 @@
+Rake::Task["assets:precompile"].enhance(["dartsass:build"])

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_mailer/railtie"
 require "action_view/railtie"
 # require "action_cable/engine"
 require "rails/test_unit/railtie"
+require "sprockets/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,4 +61,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.hosts << "short-url-manager.dev.gov.uk"
 end

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,1 @@
+Rails.application.config.dartsass.build_options << " --quiet-deps"


### PR DESCRIPTION
## Description 

LibSass has been deprecated. We're moving to Dart Sass. This follows the upgrade guide found here
https://docs.publishing.service.gov.uk/manual/migrate-to-dart-sass-from-libsass.html

## Trello card

https://trello.com/c/qeNHFPZN/1667-migrate-to-dart-sass

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
