### PR TITLE
Use Redis.new rather than Redis.current

### DIFF
--- a/app/services/organisation_importer.rb
+++ b/app/services/organisation_importer.rb
@@ -10,7 +10,7 @@ class OrganisationImporter
   end
 
   def perform!
-    Redis.current.lock("short_url_manager:organisation_importer_lock", life: 2.hours) do
+    Redis.new.lock("short_url_manager:organisation_importer_lock", life: 2.hours) do
       organisations_data = get_organisations_data
       Organisation.destroy_all
       organisations_data.each do |attrs|


### PR DESCRIPTION
## Description 

Redis.current will be deprecated in Redis 5.0.

As Redis.current ultimately calls Redis.new we can migrate this method now to pave the way for future upgrades.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
