### PR TITLE
Fix links to absolute URLs

### DIFF
--- a/app/helpers/url_helper.rb
+++ b/app/helpers/url_helper.rb
@@ -1,6 +1,6 @@
 module UrlHelper
   def govuk_url_for(path)
-    (Plek.website_root + path).to_s
+    Addressable::URI.join(Plek.website_root, path).to_s
   end
 
   def short_url_manger_url_for(path)

--- a/spec/helpers/url_helper_spec.rb
+++ b/spec/helpers/url_helper_spec.rb
@@ -5,6 +5,10 @@ describe UrlHelper do
     it "should return a fully qualified gov.uk url from the given path" do
       expect(govuk_url_for("/some/path")).to eql "http://www.dev.gov.uk/some/path"
     end
+
+    it "should leave absolute URLs unchanged" do
+      expect(govuk_url_for("http://example.com/some/other/path")).to eql "http://example.com/some/other/path"
+    end
   end
 
   describe "short_url_manger_url_for" do


### PR DESCRIPTION
govuk_url_for is used in three places in this codebase, all in view code like:

      <%= link_to short_url_request.to_path, govuk_url_for(short_url_request.to_path) %>

`to_path` can be an absolute URL though, and in this case the application will render a link like:

     <a href="http://gov.ukhttp://example.com">http://example.com</a>

which is real clown shoes stuff.

Addressable's URI.join method basically does what we want - if we're given a path, it will join that on to the website root, if we're given an absolute URL it will give us that.
