### PR TITLE
Configure action mailer to use GOV.UK Notify

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,6 +63,10 @@ Rails.application.configure do
   # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "short_url_manager_production"
 
+  config.action_mailer.delivery_method = :notify
+  config.action_mailer.notify_settings = {
+    api_key: ENV["GOVUK_NOTIFY_API_KEY"],
+  }
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
This configuration was lost during the upgrade to Rails 7.1. See 90eb0b9e9ff1da1e445aaeba242ea5efe5e7ae20
