### PR TITLE
Remove redundant govuk_admin_template config

### DIFF
--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,2 +1,0 @@
-GovukAdminTemplate.environment_label = ENV.fetch("GOVUK_ENVIRONMENT_NAME", "development").titleize
-GovukAdminTemplate.environment_style = ENV["GOVUK_ENVIRONMENT_NAME"] == "production" ? "production" : "preview"


### PR DESCRIPTION
As of version 7.0, the config is now the default gem behaviour.

https://github.com/alphagov/govuk_admin_template/blob/06d93749b4482f062e721ce300ff9509d08c4c0b/lib/govuk_admin_template.rb#L10
