### PR TITLE
Configure hosts for application

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,10 +81,10 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    /short-url-manager\..*gov.uk?/,
+  ]
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path.match?("^\/healthcheck") } }
 end


### PR DESCRIPTION
Note: the healthcheck endpoints are requested by IP, not domain, so we need to specifically exclude them from the protection.<br><br>[Trello card](https://trello.com/c/frqFN7D8)