### PR TITLE
WIP: catch "route already exists in Publishing API" error

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -64,7 +64,10 @@ class ShortUrlRequestsController < ApplicationController
         flash[:success] = "Your edit was successful."
         redirect_to short_url_request_path(@short_url_request)
       },
-      failure: -> { render "edit" },
+      failure: lambda {
+        # flash[:alert] = "Bah humbug."
+        render "edit"
+      },
     )
   end
 


### PR DESCRIPTION
We had a situation earlier whereby Short URL Manager tried and failed to apply a redirect to an existing route, despite the 'override existing' field set to 'no'. The response was a 422 and no error message, which meant the user had to get in touch with support.

We should investigate and fix the 'override existing' check, as well as do a better job at surfacing errors.

I tried and failed to recreate the scenario here in several different test files, but it may be useful as a starting point for whoever picks up the card.

Trello: https://trello.com/c/PVcAt5Ll/3178-surface-path-reserved-errors-in-ui

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
