### PR TITLE
Mount /component-guide

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,6 @@ Rails.application.routes.draw do
     GovukHealthcheck::SidekiqRedis,
   )
 
-  if Rails.env.development?
-    get "/styleguide" => "govuk_admin_template/style_guide#index"
-  end
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
+  get "/styleguide" => "govuk_admin_template/style_guide#index"
 end


### PR DESCRIPTION
This should be enabled on every app which pulls in govuk_publishing_components.

Similarly, moves the (deprecated) govuk_admin_template `/style-guide` route out of the dev block so that it's available on production. It was decided in https://trello.com/c/ITcz5b1G/3417-enable-component-guide-on-non-dev-environments that there's no reason we need to lock this down to dev env only.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
