### PR TITLE
Update GTM container ID [WHIT-3365]

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,6 @@
-<% render "layouts/google_tag_manager" %>
+<% render "layouts/google_tag_manager", {
+  gtm_id: "GTM-5T5SVMQX",
+} %>
 
 <% content_for :page_title, "GOV.UK - Short URL manager" %>
 


### PR DESCRIPTION
## What

Update the GTM container ID

## Why

Request from PAs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
