### PR TITLE
Expand db seed to include organisation model [WHIT-3649]

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,17 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+organisations = [
+  { slug: "department-for-science-innovation-and-technology", title: "DSIT" },
+  { slug: "department-for-education", title: "Department for Education" },
+]
+
+organisations.each do |organisation_hash|
+  Organisation.find_or_create_by!(slug: organisation_hash[:slug]) do |org|
+    org.title = organisation_hash[:title]
+  end
+end
+
 User.find_or_create_by!(email: "user@test.example").tap do |u|
   u.name = "Test User"
   u.permissions = %w[signin manage_short_urls request_short_urls advanced_options receive_notifications]


### PR DESCRIPTION
## What
The current db seed just contains one user.

Some models (eg organisations are required to complete the forms in the app.  We should expand the db/seeds.rb file to include a couple of test organisations.

## Why
This will help local development and allow for easy local testing of the different user journeys

## AC
Running the rails db:seed command populates the DB with the above example models

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3649)