### PR TITLE
Add design system layout [WHIT-3668]

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,5 @@
 //= link_tree ../images
 //= link_tree ../builds
 //= link application.css
+//= link application.js
 

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,3 +1,5 @@
 class DashboardController < ApplicationController
-  def dashboard; end
+  def dashboard
+    render layout: "design_system" if Rails.env.development?
+  end
 end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,6 +1,16 @@
+<% content_for :head do %>
+  <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+      <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+        gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+        gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+        gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
+      } %>
+  <% end %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/layout_for_admin", {
-  environment: "production",
+  environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
   product_name: "Short URL Manager",
-  browser_title: "A page title"
+  browser_title: "Short URL Manager - GOV.UK"
 } do %>
 <% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,0 +1,6 @@
+<%= render "govuk_publishing_components/components/layout_for_admin", {
+  environment: "production",
+  product_name: "Short URL Manager",
+  browser_title: "A page title"
+} do %>
+<% end %>

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+require "gds_api/test_helpers/publishing_api"
+
+describe DashboardController do
+  let(:user) { create(:short_url_requester_and_manager) }
+  before { login_as user }
+  it "renders the application layout" do
+    get :dashboard
+    expect(response).to render_template "application"
+  end
+end


### PR DESCRIPTION
## What
Create a new layout so we can migrate away from the govuk_admin_template layout template that is used by the app.

The layout should:

- use the layout_for_admin component in the publishing gem
- use the existing content_for(:page_title) values for the browser_title attribute
- render the google_tag_manager_script component in a content_for :head block
- maintain the existing no-js behaviour

We don’t need to add the header or footer yet, or display this anywhere - we can do those as part of the other tickets.

The layout_for_admin component expects there to be some app js (which there will be eventually).  You can create some dummy js in app/assets/javascripts/application.js which will allow the component to render.

## Why
The app currently uses the gov admin template layout in the gem, so we will need a new layout to replace this.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3668)