### PR TITLE
Remove frontend asset digests in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,6 +53,9 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  # Allow SCSS to be compiled and rendered on the fly with dartsass:watch
+  config.assets.digest = false
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 


### PR DESCRIPTION
This will allow us to use the `bin/rails dartsass:watch` command to compile SCSS files on the fly, rather than stopping the app, precompiling, starting the app during frontend development.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
