### PR TITLE
[WHIT-3642] Add header and nav components to design layout

### DIFF
--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -1,0 +1,3 @@
+html{
+  font-size: 16px
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,3 +20,5 @@
 @import "layouts/application";
 
 @import "views/shared/form_errors";
+@import "base";
+@import "govuk_publishing_components/all-components";

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -14,3 +14,19 @@
   browser_title: "Short URL Manager - GOV.UK"
 } do %>
 <% end %>
+
+<%= render "govuk_publishing_components/components/layout_header", {
+  environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
+  product_name: "Short URL Manager",
+  signout_link: true
+} %>
+
+<%= render "govuk_publishing_components/components/service_navigation", {
+  navigation_items: [
+    {
+      text: "Dashboard",
+      href: "/",
+      active: true
+    }
+  ]
+} %>


### PR DESCRIPTION
## What

Replace the app header and main nav with the equivalent components from the publishing components gem:

the layout header https://components.publishing.service.gov.uk/component-guide/layout_header

the service nav https://components.publishing.service.gov.uk/component-guide/service_navigation

A like for like replacement would have the Dashboard and Log out in the service nav.  

Use `GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment` helper for the environment

## Why

So the user understands what app and what environment they are in, and so that they can log out.

### AC

The layout header and the service nav are at the top of every page in the app.


[Jira](https://gov-uk.atlassian.net/browse/WHIT-3642)