### PR TITLE
[WHIT-3643] Add footer to design system layout

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -30,3 +30,5 @@
     }
   ]
 } %>
+
+<%= render "govuk_publishing_components/components/layout_footer" %>


### PR DESCRIPTION
## What

Replace the current footer with the publishing gem footer component https://components.publishing.service.gov.uk/component-guide/layout_footer

There aren’t any links in the current footer so we don’t need to copy any over.

## AC

The correct footer is on every page of the app

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3643)