### PR TITLE
Migrate the homepage to use cards instead of a list [WHIT-3645]

### DIFF
--- a/app/views/dashboard/dashboard.html.erb
+++ b/app/views/dashboard/dashboard.html.erb
@@ -7,12 +7,35 @@
 
 <h1>Dashboard</h1>
 
-<ul class="list-group col-md-6">
-  <% if current_user.can_request_short_urls? %>
-    <li class="list-group-item"><%= link_to "Request a new URL redirect or short URL", new_short_url_request_path %></li>
-  <% end %>
-  <% if current_user.can_manage_short_urls? %>
-    <li class="list-group-item"><%= link_to "View pending requests", short_url_requests_path %></li>
-    <li class="list-group-item"><%= link_to "View live URL redirects and short URLs", list_short_urls_path %></li>
-  <% end %>
-</ul>
+<% card_items = [] %>
+
+<% if current_user.can_request_short_urls? %>
+  <% card_items << {
+    link: {
+      text: "Request a new URL redirect or short URL",
+      path: new_short_url_request_path
+    }
+  } %>
+<% end %>
+
+<% if current_user.can_manage_short_urls? %>
+  <% card_items << {
+    link: {
+      text: "View pending requests",
+      path: short_url_requests_path
+    }
+  } %>
+
+  <% card_items << {
+    link: {
+      text: "View live URL redirects and short URLs",
+      path: list_short_urls_path
+    }
+  } %>
+<% end %>
+
+<% if card_items.any? %>
+  <%= render "govuk_publishing_components/components/cards", {
+    items: card_items
+  } %>
+<% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -13,7 +13,6 @@
   product_name: "Short URL Manager",
   browser_title: "Short URL Manager - GOV.UK"
 } do %>
-<% end %>
 
 <%= render "govuk_publishing_components/components/layout_header", {
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,
@@ -31,4 +30,9 @@
   ]
 } %>
 
+<div class="govuk-width-container">
+  <%= yield %>
+</div>
+
 <%= render "govuk_publishing_components/components/layout_footer" %>
+<% end %>


### PR DESCRIPTION
## What
Migrate the home page, replacing the onward links list with an appropriate component from the publishing components gem (maybe [cards](https://components.publishing.service.gov.uk/component-guide/cards)?).  It might be worth having a different title and some descriptive text for each link, rather than the current links.

The cards (and other listing components) accept an array of items to display, so it might be worth creating a wrapping view component that works out what to display to the user based on their permissions.

## Why
So:
- users can navigate to the part of the app they need
- users only see onward links to parts of the app they have permission for

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3645)

## Before
<img width="757" height="235" alt="Screenshot 2026-06-30 at 10 58 32" src="https://github.com/user-attachments/assets/2ce5813e-b0e7-42b1-98e0-1e638c0708ef" />

## After

<img width="1032" height="235" alt="Screenshot 2026-06-30 at 10 57 55" src="https://github.com/user-attachments/assets/f9f8ee72-be0c-4fac-ad08-853cb678e0b9" />
