### PR TITLE
Migrate breadcrumbs to use the design system [WHIT-3644]

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,10 @@
 module ApplicationHelper
-  def crumb_li(title, path, active)
+  def crumb_li(title, path)
     options = {}
-    options[:class] = "active" if active
+    options[:class] = "govuk-breadcrumbs__list-item"
 
     tag.li nil, **options do
-      active ? title : link_to(title, path)
+      link_to(title, path, class: "govuk-breadcrumbs__link")
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,8 +25,8 @@
 
   <% breadcrumbs.tap do |links| %>
     <% if links.any? %>
-      <ul class='breadcrumb'>
-        <% links.each do |link| %><%= crumb_li(link.text, link.url, link.current?) %><% end %>
+      <ul class="govuk-breadcrumbs__list">
+        <% links.each do |link| %><%= crumb_li(link.text, link.url) %><% end %>
       </ul>
     <% end %>
   <% end %>


### PR DESCRIPTION
## What

Follow the [guidance for the new breadcrumbs](https://design-system.service.gov.uk/components/breadcrumbs/) - unlike the current ones, they should not contain the current page.

## Why

So the users know where they are in the app and in their redirect journey.

### AC

Breadcrumbs are rendered at the top of each page in the app, underneath the service nav.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3644)


Screenshots:
Before:
<img width="1166" height="75" alt="Screenshot 2026-07-01 at 15 49 44" src="https://github.com/user-attachments/assets/66a415a9-8d79-430d-ad6d-816dc2c92ab4" />

After:
<img width="1166" height="75" alt="Screenshot 2026-07-01 at 15 49 52" src="https://github.com/user-attachments/assets/e8131d9f-e8eb-441a-b680-a510f1998dfc" />
