### PR TITLE
Migrate each element on form partial [WHIT-3646]

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,2 @@
+//= require govuk_publishing_components/dependencies
+//= require govuk_publishing_components/all_components

--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -1,4 +1,6 @@
 class ShortUrlRequestsController < ApplicationController
+  layout "design_system", only: %i[new create edit update] if Rails.env.development?
+
   before_action :authorise_as_short_url_requester!, only: %i[new create]
   before_action :authorise_as_short_url_manager!, only: %i[index show accept new_rejection reject list_short_urls edit update destroy remove]
   before_action :get_short_url_request, only: %i[edit update show accept new_rejection reject destroy remove]

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,4 +1,8 @@
 module FormHelper
+  def error_message_for(attribute, errors)
+    errors.full_messages_for(attribute).first
+  end
+
   def render_errors_for(model, leading_message: nil)
     if model.errors.any?
       render partial: "shared/form_errors",

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -1,85 +1,162 @@
 <%= form_for @short_url_request do |f| %>
-  <dl>
-    <dt>State:</dt>
-    <dd><%= @short_url_request.state.titleize %></dd>
-  </dl>
+  <%= render "govuk_publishing_components/components/summary_list", {
+  items: [
+    {
+      field: "State:",
+      value: @short_url_request.state.titleize
+    }
+  ]
+  } %>
+
   <%= render_errors_for @short_url_request, leading_message: "Your request for a URL redirect or short URL could not be made for the following reasons:" %>
-  <fieldset>
-    <div class="form-group">
-      <%= f.label :from_path %>
-      <%= f.text_field :from_path, disabled: @short_url_request.persisted?, class: 'form-control input-md-8' %>
-      <p class="help-block">This is the URL or the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").</p>
-    </div>
+  <fieldset> 
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: "From or short URL"
+      },
+      name: f.field_name(:from_path),
+      id: f.field_id(:from_path),
+      value: @short_url_request.from_path,
+      error_message: error_message_for(:from_path, @short_url_request.errors),
+      readonly: @short_url_request.persisted?,
+      heading_level: 2,
+      heading_size: "s",
+      hint: 'This is the URL or the short URL to redirect the user from. Please specify it as a relative path (eg. "/hmrc/tax-evasion").'
+    } %>
 
-    <div class="form-group">
-      <%= f.label :to_path %>
-      <%= f.text_field :to_path, class: 'form-control input-md-8' %>
-      <p class="help-block">This is the URL to redirect the user to. The following types of target URL are supported:</p>
-      <ul class="help-block">
-        <li>Internal gov.uk links, eg. <strong>/government/publications/what-hmrc-does-to-prevent-tax-evasion</strong></li>
-        <li>External gov.uk subdomain links, eg. <strong>https://my-title.external.gov.uk/an-optional-path</strong></li>
-        <li>External government subdomain links, eg. <strong><%= ShortUrlValidations.allow_host_display_list %></strong></li>
-      </ul>
-    </div>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: "Target URL"
+      },
+      name: f.field_name(:to_path),
+      id: f.field_id(:to_path),
+      value: @short_url_request.to_path,
+      error_message: error_message_for(:to_path, @short_url_request.errors),
+      heading_level: 2,
+      heading_size: "s",
+      hint: sanitize("This is the URL to redirect the user to. The following types of target URL are supported:
+        <ul class='govuk-list govuk-list--bullet'>
+          <li>Internal gov.uk links, eg. <strong>/government/publications/what-hmrc-does-to-prevent-tax-evasion</strong></li>
+          <li>External gov.uk subdomain links, eg. <strong>https://my-title.external.gov.uk/an-optional-path</strong></li>
+          <li>External government subdomain links, eg. <strong>#{ShortUrlValidations.allow_host_display_list}</strong></li>
+        </ul>",
+        tags: %w(ul li strong),
+        attributes: %w(class)
+      )
+    } %>
 
-    <div class="form-group">
-      <%= f.label :organisation_slug %>
-      <%= f.select :organisation_slug, options_for_select(organisations.map {|org| [org.title, org.slug] }, @short_url_request.organisation_slug), {}, class: 'form-control input-md-6' %>
-    </div>
+    <%= render "govuk_publishing_components/components/select", {
+      id: f.field_id(:organisation_slug),
+      name: f.field_name(:organisation_slug),
+      label: "Organisation",
+      heading_size: "s",
+      options: organisations.map { |org|
+        {
+          text: org.title,
+          value: org.slug,
+          selected: org.slug == @short_url_request.organisation_slug
+        }
+      }
+    } %>
 
-    <div class="form-group">
-      <%= f.label :reason %>
-      <%= f.text_area :reason, class: 'form-control input-md-8' %>
-      <p class="help-block">Please explain the reason for this request, as requests without a clear and valid reason will be denied. Include any Zendesk ticket URL or other information if available.</p>
-    </div>
-  </fieldset>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Reason",
+        heading_size: "s"
+      },
+      name: f.field_name(:reason),
+      value: @short_url_request.reason,
+      error_message: error_message_for(:reason, @short_url_request.errors),
+      hint: "Please explain the reason for this request, as requests without a clear and valid reason will be denied. Include any Zendesk ticket URL or other information if available."
+    } %>
 
-  <fieldset>
-    <div class="form-group">
-      <% if @short_url_request.new_record? %>
-        <%= f.submit "Submit request", class: 'btn btn-success' %>
-        <%= link_to "Cancel", '/', class: "btn btn-default add-left-margin" %>
-      <% else %>
-        <%= f.submit "Update", class: 'btn btn-success' %>
-        <%= link_to "Cancel", short_url_request_path(@short_url_request), class: "btn btn-default add-left-margin" %>
+    <% if allow_use_of_advanced_options? %>
+      <% advanced_options_html = capture do %>
+        <p class="govuk-body govuk-!-margin-bottom-4">Leave as defaults if unsure.</p>
+        <%= render "govuk_publishing_components/components/select", {
+          id: f.field_id(:override_existing),
+          name: f.field_name(:override_existing),
+          label: "Override existing",
+          hint: sanitize("This will allow the redirect to override any existing content for this path. Be <strong>very careful</strong> with this option."),
+          heading_size: "s",
+          options: [
+            { text: "No", value: "false", selected: @short_url_request.override_existing != true },
+            { text: "Yes", value: "true", selected: @short_url_request.override_existing == true }
+          ]
+        } %>
+
+        <%= render "govuk_publishing_components/components/select", {
+          id: f.field_id(:route_type),
+          name: f.field_name(:route_type),
+          label: "From redirects",
+          hint: sanitize("Do not redirect all pages unless you need any page with an address which starts with your input to also be redirected. For example, if you add <strong>gov.uk/address/</strong> then <strong>gov.uk/address/gone</strong> would also be redirected."),
+          heading_size: "s",
+          options: [
+            { text: "Exact URL only", value: "exact", selected: @short_url_request.route_type == "exact" },
+            { text: "URL and all pages under it", value: "prefix", selected: @short_url_request.route_type == "prefix" }
+          ]
+        } %>
+
+        <%= render "govuk_publishing_components/components/select", {
+          id: f.field_id(:segments_mode),
+          name: f.field_name(:segments_mode),
+          label: "Segments",
+          heading_size: "s",
+          options: [
+            { text: "Discard", value: "ignore", selected: @short_url_request.segments_mode == "ignore" },
+            { text: "Keep", value: "preserve", selected: @short_url_request.segments_mode == "preserve" }
+          ]
+        } %>
+
+        <h3 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-3">Help with segments</h3>
+
+        <h4 class="govuk-heading-s govuk-!-margin-bottom-2">Discard</h4>
+        <p class="govuk-body govuk-!-margin-bottom-1"><strong>Using "Exact URL only"</strong></p>
+        <p class="govuk-body">For source <strong>/from?q=123</strong> and target URL <strong>/target</strong> will redirect to <strong>/target</strong></p>
+
+        <p class="govuk-body govuk-!-margin-bottom-1"><strong>Using "URL and all pages under it"</strong></p>
+        <p class="govuk-body">For source <strong>/from?q=123</strong> and target URL <strong>/target</strong> will redirect to <strong>/target</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target</strong></p>
+
+        <h4 class="govuk-heading-s govuk-!-margin-top-4 govuk-!-margin-bottom-2">Keep</h4>
+        <p class="govuk-body govuk-!-margin-bottom-1"><strong>Using "Exact URL only"</strong></p>
+        <p class="govuk-body">For source <strong>/from/?q=123</strong> and target URL <strong>/target</strong> will redirect to <strong>/target?q=123</strong></p>
+
+        <p class="govuk-body govuk-!-margin-bottom-1"><strong>Using "URL and all pages under it"</strong></p>
+        <p class="govuk-body govuk-!-margin-bottom-0">For source <strong>/from/?q=123</strong> and target URL <strong>/target</strong> will redirect to <strong>/target/page/?q=123</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target/doe/a/deer</strong></p>
       <% end %>
-    </div>
-  </fieldset>
 
-  <% if allow_use_of_advanced_options? %>
-  <fieldset>
-    <h2>Advanced options</h2>
-    <p>Leave as defaults if unsure.</p>
-    <div class="form-group">
-      <%= f.label :override_existing %>
-      <%= f.select :override_existing, options_for_select({ "No" => false, "Yes" => true }, @short_url_request.override_existing), {}, class: 'form-control input-md-6' %>
-      <p>This will allow the redirect to override any existing content for this path. Be <strong>very careful</strong> with this option.</p>
-    </div>
-    <div class="form-group">
-      <%= f.label :route_type, 'From redirects' %>
-      <%= f.select :route_type, options_for_select({ "Exact URL only" => "exact", "URL and all pages under it" => "prefix" }, @short_url_request.route_type), {}, class: 'form-control input-md-6' %>
-      <p>Do not redirect all pages unless you need any page with an address which starts with your input to also be redirected. For example, if you add <strong>gov.uk/address/</strong> then <strong>gov.uk/address/gone</strong> would also be redirected.</p>
-    </div>
+      <div class="govuk-!-margin-top-6">
+        <%= render "govuk_publishing_components/components/details", {
+            title: "Advanced options"
+          } do %>
+            <%= advanced_options_html %>
+        <% end %>
+      </div>
+    <% end %>
 
-    <div class="form-group">
-      <%= f.label :segments_mode, 'Segments' %>
-      <%= f.select :segments_mode, options_for_select({ "Discard" => "ignore", "Keep" => "preserve" }, @short_url_request.segments_mode), {}, class: 'form-control input-md-6' %>
-    </div>
-
-    <h3>Help with Segments</h3>
-    <h4>Discard</h4>
-    <h5>Using "Exact URL only"</h5>
-    <p>For source <strong>/from?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target</strong></p>
-    <h5>Using "URL and all pages under it"</h5>
-    <p>For source <strong>/from?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target</strong></p>
-
-
-    <h4>Keep</h4>
-    <h5>Using "Exact URL only"</h5>
-    <p>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target?q=123</strong></p>
-    <h5>Using "URL and all pages under it"</h5>
-    <p>For source <strong>/from/?q=123</strong> and target url <strong>/target</strong> will redirect to <strong>/target/page/?q=123</strong> and also <strong>/from/doe/a/deer</strong> will redirect to <strong>/target/doe/a/deer</strong></p>
-
-  </fieldset>
-  <% end %>
+    <% if @short_url_request.new_record? %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Submit request",
+        type: "submit",
+        inline_layout: true
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Cancel",
+        href: "/",
+        secondary_solid: true,
+        inline_layout: true
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Update",
+        type: "submit",
+        inline_layout: true
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Cancel",
+        href: short_url_request_path(@short_url_request),
+        secondary_solid: true,
+        inline_layout: true
+      } %>
+    <% end %>
 <%- end -%>

--- a/app/views/short_url_requests/new.html.erb
+++ b/app/views/short_url_requests/new.html.erb
@@ -2,6 +2,6 @@
 
 <h1 class="page-title-with-border">Request a new URL redirect or short URL</h1>
 
-<p>Please read <a href="https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-short-url">the guidance on short URL requests</a> before making a request.</p>
+<p class="govuk-body govuk-!-margin-bottom-4">Please read <a href="https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-short-url">the guidance on short URL requests</a> before making a request.</p>
 
 <%= render :partial => 'form' %>


### PR DESCRIPTION
## What

The current _form.html.erb shared partial view is present in each journey and forms a significant part of the migration work.

Replace each element on the form with the equivalent from the publishing components gem:

- all form fields (inputs / selects / textareas etc)
- the buttons the buttons
- write a helper method that accepts a field value and the form’s errors object and retrieves the field’s error message (or nil)
- the ‘advanced options’ section can be moved to be above the buttons

## Why

So users can create, edit, delete and reject short urls and redirects using the app.

### AC

The form shared view no longer uses any bootstrap styles or components

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3646)

**Screenshots**


**Before:**

<img width="2030" height="3532" alt="image (1)" src="https://github.com/user-attachments/assets/a25d1c86-2ecf-4af5-a6fe-3d0cb2eb9c06" />


**After:**
<img width="1342" height="1060" alt="Screenshot 2026-07-15 at 11 42 09" src="https://github.com/user-attachments/assets/852b8218-e761-4c76-ba54-92377d57d527" />
<img width="1342" height="922" alt="Screenshot 2026-07-15 at 11 42 26" src="https://github.com/user-attachments/assets/a58a2b91-bc9d-4c4b-b03a-e8a58e3c1020" />

