### PR TITLE
Migrate form_errors partial to design system [WHIT-3648]

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -6,7 +6,7 @@ module FormHelper
   def render_errors_for(model, leading_message: nil)
     if model.errors.any?
       render partial: "shared/form_errors",
-             locals: { error_messages: model.errors.full_messages,
+             locals: { errors: model.errors,
                        leading_message: leading_message || default_leading_error_message_for(model) }
     end
   end

--- a/app/views/shared/_form_errors.html.erb
+++ b/app/views/shared/_form_errors.html.erb
@@ -1,8 +1,11 @@
-<div class="form-errors">
-  <p><%= leading_message %></p>
-  <ul>
-    <%- error_messages.each do |error_message| -%>
-      <li><%= error_message %></li>
-    <%- end -%>
-  </ul>
-</div>
+<%= render "govuk_publishing_components/components/error_summary", {
+  title: "There is a problem",
+  description: leading_message,
+  items: errors.map { |error|
+    {
+      text: error.full_message,
+      href: "#short_url_request_#{error.attribute.to_s}",
+      target: "_self"
+    }
+  }
+} %>

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -8,7 +8,13 @@
   ]
   } %>
 
-  <%= render_errors_for @short_url_request, leading_message: "Your request for a URL redirect or short URL could not be made for the following reasons:" %>
+  <% if @short_url_request.errors.any? %>
+  <%= render "shared/form_errors", {
+    errors: @short_url_request.errors,
+    leading_message: "Your request for a URL redirect or short URL could not be made for the following reasons:"
+  } %>
+  <% end %>
+
   <fieldset> 
     <%= render "govuk_publishing_components/components/input", {
       label: {
@@ -65,6 +71,7 @@
         heading_size: "s"
       },
       name: f.field_name(:reason),
+      textarea_id: f.field_id(:reason),
       value: @short_url_request.reason,
       error_message: error_message_for(:reason, @short_url_request.errors),
       hint: "Please explain the reason for this request, as requests without a clear and valid reason will be denied. Include any Zendesk ticket URL or other information if available."

--- a/spec/helpers/form_helper_spec.rb
+++ b/spec/helpers/form_helper_spec.rb
@@ -35,8 +35,8 @@ describe FormHelper do
 
       describe "specific errors" do
         it "should render errors in a list" do
-          expect(rendered).to have_css("div.form-errors ul li", text: "Attribute 1 can't be blank")
-          expect(rendered).to have_css("div.form-errors ul li", text: "Attribute 2 can't be a small lemon")
+          expect(rendered).to have_css(".govuk-error-summary__list li", text: "Attribute 1 can't be blank")
+          expect(rendered).to have_css(".govuk-error-summary__list li", text: "Attribute 2 can't be a small lemon")
         end
       end
 
@@ -45,7 +45,7 @@ describe FormHelper do
           let(:leading_message) { nil }
 
           it "should have a default message based on the model's class name" do
-            expect(rendered).to have_css("div.form-errors p", text: "The test model could not be saved for the following reasons:")
+            expect(rendered).to have_css(".govuk-error-summary", text: "The test model could not be saved for the following reasons:")
           end
         end
 
@@ -53,7 +53,7 @@ describe FormHelper do
           let(:leading_message) { "Your death ray could not be activated." }
 
           it "should show the custom leading_message" do
-            expect(rendered).to have_css("div.form-errors p", text: "Your death ray could not be activated.")
+            expect(rendered).to have_css(".govuk-error-summary", text: "Your death ray could not be activated.")
           end
         end
       end


### PR DESCRIPTION
## What

The current _form_errors.html.erb shared partial view is present in each journey and forms a significant part of the migration work.

Includes:

- replacing the partial with the error summary component (you might need to create a wrapping component that parses the form’s errors and formats them as required by the error summary - see https://components.publishing.service.gov.uk/component-guide/error_summary/with_custom_target_on_links). 

Doesn’t include moving the error summary to the top of the page or changing the page <title>, since these will be controlled by other views

## Why

So users get clear, actionable and accessible feedback on the errors they have made when using the app.

### AC

The form errors view doesn’t render any bootstrap components and does render the error summary with links to the erroring inputs as per the design system / publishing components gem

### Screenshots
Before:
<img width="1604" height="236" alt="Screenshot 2026-07-20 at 15 49 18" src="https://github.com/user-attachments/assets/a1d6a967-57be-4434-9534-a1e43e6f37a6" />

After:
<img width="900" height="236" alt="Screenshot 2026-07-20 at 15 48 59" src="https://github.com/user-attachments/assets/865d2427-8928-4396-b1b9-b3b542a927a3" />

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3648)