### PR TITLE
Use design system layout for new URL request journeys [WHIT-3647]

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -1,5 +1,6 @@
 class ShortUrlRequestsController < ApplicationController
-  layout "design_system", only: %i[new create edit update] if Rails.env.development?
+  layout "design_system", only: %i[new]
+  layout "design_system", only: %i[edit create update] if Rails.env.development?
 
   before_action :authorise_as_short_url_requester!, only: %i[new create]
   before_action :authorise_as_short_url_manager!, only: %i[index show accept new_rejection reject list_short_urls edit update destroy remove]

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -24,8 +24,11 @@
   navigation_items: [
     {
       text: "Dashboard",
-      href: "/",
-      active: true
+      href: "/"
+    },
+    {
+      text: "Swtich app",
+      href: Plek.external_url_for("signon")
     }
   ]
 } %>

--- a/app/views/short_url_requests/new.html.erb
+++ b/app/views/short_url_requests/new.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :new_short_url_request %>
 
-<h1 class="page-title-with-border">Request a new URL redirect or short URL</h1>
+<h1 class="govuk-heading-xl">Request a new URL redirect or short URL</h1>
 
 <p class="govuk-body govuk-!-margin-bottom-4">Please read <a href="https://guidance.publishing.service.gov.uk/accounts-support/make-content-requests/ask-short-url">the guidance on short URL requests</a> before making a request.</p>
 


### PR DESCRIPTION
## What
This PR removes the gaurd clause that only showed the design system whilst developing locally. It also fixes the heading in new.html.erb to be more consistent with the GOV.UK design system. It also adds the ability to "Switch app" from the navigation bar.

## Why
This is part of the work related to this ticket [https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3647](Jira)

So that users can:

- confirm they want to overwrite an existing redirect
- see any errors in their request and fix them
- understand when they have successfully requested a redirect / short url

### AC

All the user journeys for requesting a new redirect use the design system and associated components 

## Screenshots
Before:
<img width="2048" height="1906" alt="image (5)" src="https://github.com/user-attachments/assets/7693f3c8-e328-4b9b-8631-047676e422cf" />
<img width="2030" height="3532" alt="image (1)" src="https://github.com/user-attachments/assets/13e5bbf5-231b-4dd2-a121-841eefad3569" />
<img width="1556" height="1604" alt="image (3)" src="https://github.com/user-attachments/assets/30ad3115-dfa6-4687-8d27-2ad21519d256" />
<img width="2030" height="2420" alt="image (4)" src="https://github.com/user-attachments/assets/5b63e935-d77b-45ee-8b16-e486727cce7f" />
<img width="2048" height="1906" alt="image (2)" src="https://github.com/user-attachments/assets/2f648884-2849-4c83-9afd-ff4189136bf2" />

After:
<img width="1103" height="739" alt="Screenshot 2026-07-21 at 15 02 55" src="https://github.com/user-attachments/assets/b9fd7aab-345f-48e5-834e-5a359cd75f65" />
<img width="1103" height="1256" alt="Screenshot 2026-07-21 at 15 04 20" src="https://github.com/user-attachments/assets/c3c9a043-c187-4e60-81a3-eb9ecf0e1e98" />
<img width="1103" height="1188" alt="Screenshot 2026-07-21 at 15 06 34" src="https://github.com/user-attachments/assets/1938d859-9fd3-466b-bbea-da9b996f535b" />
<img width="1103" height="1262" alt="Screenshot 2026-07-21 at 15 10 24" src="https://github.com/user-attachments/assets/dc6ec55d-959d-4c19-98b1-3cb13a51bf59" />
<img width="1103" height="783" alt="Screenshot 2026-07-21 at 15 05 23" src="https://github.com/user-attachments/assets/45411f12-dacf-4665-a635-c9843027bde3" />

