### PR TITLE
Migrate breadcrumbs to design system [WHIT-3644]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "plek"
 gem "redis", require: false # Used by the Organisation importer as a locking mechanism
 gem "sentry-sidekiq"
 gem "terser"
+gem "view_component"
 gem "whenever", require: false
 gem "will_paginate_mongoid"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,6 +713,10 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     version_gem (1.1.14)
+    view_component (4.12.0)
+      actionview (>= 7.1.0)
+      activesupport (>= 7.1.0)
+      concurrent-ruby (~> 1)
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-oauth2 (0.0.1)
@@ -772,6 +776,7 @@ DEPENDENCIES
   simplecov
   simplecov-rcov
   terser
+  view_component
   webmock
   whenever
   will_paginate_mongoid

--- a/app/components/breadcrumbs_component.html.erb
+++ b/app/components/breadcrumbs_component.html.erb
@@ -1,0 +1,4 @@
+<%= render "govuk_publishing_components/components/breadcrumbs", {
+  collapse_on_mobile: true,
+  breadcrumbs: crumbs
+} %>

--- a/app/components/breadcrumbs_component.rb
+++ b/app/components/breadcrumbs_component.rb
@@ -1,0 +1,20 @@
+class BreadcrumbsComponent < ViewComponent::Base
+  def initialize(breadcrumbs)
+    super()
+    @breadcrumbs = breadcrumbs
+  end
+
+  def crumbs
+    all_but_last_crumb = @breadcrumbs.reject { |crumb| crumb == @breadcrumbs.last }
+    all_but_last_crumb.map do |crumb|
+      {
+        title: crumb.text,
+        url: crumb.url,
+      }
+    end
+  end
+
+  def render?
+    crumbs.size > 1
+  end
+end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -34,6 +34,7 @@
 } %>
 
 <div class="govuk-width-container">
+  <%= render BreadcrumbsComponent.new(breadcrumbs) %>
   <main class="govuk-main-wrapper" id="main-content">
     <%= yield %>
   </main>

--- a/spec/components/breadcrumbs_component_spec.rb
+++ b/spec/components/breadcrumbs_component_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe BreadcrumbsComponent, type: :component do
+  include ViewComponent::TestHelpers
+
+  let(:root) do
+    instance_double("Breadcrumb", text: "Dashboard", url: "/")
+  end
+
+  let(:index) do
+    instance_double(
+      "Breadcrumb",
+      text: "URL redirect or short URL requests",
+      url: "/short_url_requests",
+    )
+  end
+
+  let(:current) do
+    instance_double(
+      "Breadcrumb",
+      text: "View short URL request",
+      url: "/short_url_requests/1",
+    )
+  end
+
+  describe "rendering" do
+    it "renders all but the current breadcrumb" do
+      render_inline(described_class.new([root, index, current]))
+
+      expect(rendered_content).to include("Dashboard")
+      expect(rendered_content).to include("URL redirect or short URL requests")
+      expect(rendered_content).to include('href="/"')
+      expect(rendered_content).to include('href="/short_url_requests"')
+
+      expect(rendered_content).not_to include("View short URL request")
+      expect(rendered_content).not_to include('href="/short_url_requests/1"')
+    end
+
+    it "renders nothing when there is only one breadcrumb to display" do
+      render_inline(described_class.new([root, current]))
+
+      expect(rendered_content).to be_blank
+    end
+
+    it "renders nothing when there are no parent breadcrumbs" do
+      render_inline(described_class.new([current]))
+
+      expect(rendered_content).to be_blank
+    end
+  end
+end


### PR DESCRIPTION
## What

Replace the current breadcrumbs with ones from the publishing component gem - https://components.publishing.service.gov.uk/component-guide/breadcrumbs.

- Gretel gem is used to display the breadcrumbs, these are configured in `config/breadcrumbs.rb`
- create a new BreadcrumbsComponent view component, that accepts the breadcrumbs variable currently used application.erb.html
- map over these to return an array in the format required by the publishing components gem
- drop the current page if we can’t configure Gretel to do that for us

## Why

So the users know where they are in the app and in their redirect journey.

### AC

Breadcrumbs are rendered at the top of each page in the app, underneath the service nav.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3644)

## Screenshots:
Before:
<img width="1103" height="112" alt="Screenshot 2026-07-23 at 15 56 24" src="https://github.com/user-attachments/assets/ef92a7a3-c8d1-444f-a5af-49c952d0739c" />

After:
<img width="1103" height="159" alt="Screenshot 2026-07-23 at 15 55 39" src="https://github.com/user-attachments/assets/3f01fa9f-bedd-4d0d-b657-f085ce340c8d" />
