### PR TITLE
Migrate view pending list [WHIT-3650]

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -1,5 +1,5 @@
 class ShortUrlRequestsController < ApplicationController
-  layout "design_system", only: %i[new]
+  layout "design_system", only: %i[new index create]
   layout "design_system", only: %i[edit create update] if Rails.env.development?
 
   before_action :authorise_as_short_url_requester!, only: %i[new create]

--- a/app/views/dashboard/dashboard.html.erb
+++ b/app/views/dashboard/dashboard.html.erb
@@ -1,11 +1,5 @@
 <% breadcrumb :root %>
 
-<% if flash[:success] %>
-  <%= render "govuk_publishing_components/components/success_alert", {
-    message: flash[:success]
-  } %>
-<% end %>
-
 <%= render "govuk_publishing_components/components/notice", {
   title: "Migration Alert",
   description: "We are currently migrating this application to use the GOV.UK design system over the coming weeks. There should not be any changes to the functionality. If you experience any issues please contact publishing service support via Zendesk."

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -36,6 +36,11 @@
 <div class="govuk-width-container">
   <%= render BreadcrumbsComponent.new(breadcrumbs) %>
   <main class="govuk-main-wrapper" id="main-content">
+    <% if flash[:success] %>
+      <%= render "govuk_publishing_components/components/success_alert", {
+        message: flash[:success]
+      } %>
+    <% end %>
     <%= yield %>
   </main>
 </div>

--- a/app/views/short_url_requests/index.html.erb
+++ b/app/views/short_url_requests/index.html.erb
@@ -1,18 +1,38 @@
 <% breadcrumb :short_url_requests %>
 
-<h1>URL redirect and short URL requests</h1>
+<h1 class="govuk-heading-xl">Pending URL redirect and short URL requests</h1>
 
 <%= will_paginate @short_url_requests %>
-<table class="table table-bordered table-hover">
-  <thead>
-    <tr class="table-header">
-      <th>Organisation</th>
-      <th>From</th>
-      <th>To</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= render @short_url_requests %>
-  </tbody>
-</table>
+<%= render "govuk_publishing_components/components/table", {
+  head: [
+    {
+      text: "Organisation"
+    },
+    {
+      text: "From",
+    },
+    {
+      text: "To",
+    },
+    {
+      text: "Action"
+    }
+  ],
+  rows: @short_url_requests.map { |r|
+    [
+      { 
+        text: r.organisation_title
+      },
+      { 
+        text: r.from_path
+      },
+      { 
+        text: r.to_path
+      },
+      {
+        text: link_to("View", short_url_request_path(r))
+      }
+    ]
+  }
+} %>
 <%= will_paginate @short_url_requests %>

--- a/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
@@ -57,7 +57,9 @@ feature "Short URL manager responds to short URL requests" do
     perform_enqueued_jobs do
       visit short_url_requests_path
 
-      click_on "Ministry of Beards"
+      within("tr", text: "Ministry of Beards") do
+        click_on "View"
+      end
       click_on "Accept and create redirect"
     end
 
@@ -76,7 +78,9 @@ feature "Short URL manager responds to short URL requests" do
     perform_enqueued_jobs do
       visit short_url_requests_path
 
-      click_on "Ministry of Beards"
+      within("tr", text: "Ministry of Beards") do
+        click_on "View"
+      end
       click_on "Reject"
       fill_in "Reason", with: "Beards are soo last season."
       click_on "Reject"
@@ -132,7 +136,9 @@ feature "Short URL manager responds to short URL requests" do
     scenario "Short URL manager is shown a warning message" do
       visit short_url_requests_path
 
-      click_on "Ministry of Hair"
+      within("tr", text: "Ministry of Hair") do
+        click_on "View"
+      end
 
       within("#existing-redirect-warning") do
         expect(page).to have_content accepted_request.from_path

--- a/spec/features/short_url_manager_views_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_views_furl_requests_spec.rb
@@ -48,7 +48,9 @@ feature "Short URL manager finds information on short_url requests" do
 
     visit short_url_requests_path
 
-    click_on "Ministry of Beards"
+    within("tr", text: "Ministry of Beards") do
+      click_on "View"
+    end
 
     expect(page).to have_content "Ministry of Beards"
     expect(page).to have_content "12:00pm, 1 January 2014"
@@ -85,7 +87,9 @@ feature "Short URL manager finds information on short_url requests" do
 
     visit short_url_requests_path
 
-    click_on "Ministry of Beards"
+    within("tr", text: "Ministry of Beards") do
+      click_on "View"
+    end
 
     within ".other-requests" do
       # Don't have the main request in the other requests section


### PR DESCRIPTION
## What

Migrate the “View pending requests” list page to the design system. Currently, the clickable table rows are not accessible and will need to be replaced. The table should contain the same columns and data as the existing table, but displayed using a new component.

The table should contain an additional column with a ‘View’ link at the end of each row, clicking on this link takes you to the same place as clicking on the row in the old version.

This does not include adding pagination to the table.

Implement Sumi’s comments in the mural:

- changing page title to “Pending requests”

## Why

So that users can view outstanding requests that need to be processed.

### AC

The ‘view pending' list screen no longer uses any boostrap components, only components using the publishing components gem or the design system.

### Screenshots
Before:
<img width="947" height="690" alt="Screenshot 2026-08-07 at 09 42 09" src="https://github.com/user-attachments/assets/abe1accd-020f-4fb4-901d-689e301b4771" />

After:
<img width="1113" height="307" alt="Screenshot 2026-08-07 at 09 42 25" src="https://github.com/user-attachments/assets/476b231d-dbd0-4d73-802a-c138d50bf592" />


[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3650)