### PR TITLE
Migrate the pending request details screen [WHIT-3655]

### DIFF
--- a/app/assets/stylesheets/modules/_other_requests.scss
+++ b/app/assets/stylesheets/modules/_other_requests.scss
@@ -1,5 +1,3 @@
-.other-requests {
-  ol {
-    font-size: 85%;
-  }
+.other-requests .govuk-summary-list__value {
+  font-weight: 400;
 }

--- a/app/components/short_url_request_data_component.html.erb
+++ b/app/components/short_url_request_data_component.html.erb
@@ -1,0 +1,1 @@
+<%= render "govuk_publishing_components/components/summary_list", items: items %>

--- a/app/components/short_url_request_data_component.rb
+++ b/app/components/short_url_request_data_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class ShortUrlRequestDataComponent < ViewComponent::Base
+  def initialize(short_url_request:, show_short_url: true)
+    super()
+    @short_url_request = short_url_request
+    @show_short_url = show_short_url
+  end
+
+  def items
+    [
+      {
+        field: "Organisation",
+        value: @short_url_request.organisation_title,
+      },
+      {
+        field: "Requested at",
+        value: @short_url_request.created_at.to_fs(:govuk_date),
+      },
+      *short_url_item,
+      {
+        field: "Target URL",
+        value: helpers.link_to(@short_url_request.to_path, helpers.govuk_url_for(@short_url_request.to_path)),
+      },
+      {
+        field: "Override existing",
+        value: @short_url_request.override_existing? ? "Yes" : "No",
+      },
+      {
+        field: "Route type",
+        value: @short_url_request.route_type,
+      },
+      {
+        field: "Segments mode",
+        value: @short_url_request.segments_mode,
+      },
+      {
+        field: "Reason",
+        value: @short_url_request.reason,
+      },
+      {
+        field: "Contact email",
+        value: @short_url_request.contact_email,
+      },
+      {
+        field: "State",
+        value: @short_url_request.state.titleize,
+      },
+    ]
+  end
+
+private
+
+  def short_url_item
+    return [] unless @show_short_url
+
+    [{ field: "URL redirect or short URL", value: @short_url_request.from_path }]
+  end
+end

--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -1,6 +1,6 @@
 class ShortUrlRequestsController < ApplicationController
-  layout "design_system", only: %i[new index create]
-  layout "design_system", only: %i[edit create update] if Rails.env.development?
+  layout "design_system", only: %i[new show index create]
+  layout "design_system", only: %i[new edit show index create update] if Rails.env.development?
 
   before_action :authorise_as_short_url_requester!, only: %i[new create]
   before_action :authorise_as_short_url_manager!, only: %i[index show accept new_rejection reject list_short_urls edit update destroy remove]

--- a/app/views/short_url_requests/_existing_redirect.html.erb
+++ b/app/views/short_url_requests/_existing_redirect.html.erb
@@ -1,5 +1,5 @@
-<div class="alert alert-danger" id="existing-redirect-warning" role="alert">
-  <strong><%= existing_redirect.from_path %> already redirects to
-    <%= existing_redirect.to_path %>!</strong> Accepting this request will overwrite
-  that.
-</div>
+<%= render "govuk_publishing_components/components/warning_text", {
+  id: "existing-redirect-warning",
+  text: "#{existing_redirect.from_path} already redirects to #{existing_redirect.to_path}! Accepting this request will overwrite that.",
+  highlight_text: true
+} %>

--- a/app/views/short_url_requests/_short_url_request_data.html.erb
+++ b/app/views/short_url_requests/_short_url_request_data.html.erb
@@ -1,33 +1,3 @@
-<dl>
-  <dt>By:</dt>
-  <dd><%= short_url_request.organisation_title %></dd>
-
-  <dt>Requested at:</dt>
-  <dd><%= short_url_request.created_at.to_fs(:govuk_date) %></dd>
-
-  <% if show_short_url %>
-    <dt>URL redirect or short URL:</dt>
-    <dd><%= short_url_request.from_path %></dd>
-  <% end %>
-
-  <dt>Target URL:</dt>
-  <dd><%= link_to short_url_request.to_path, govuk_url_for(short_url_request.to_path) %></dd>
-
-  <dt>Override existing:</dt>
-  <dd><%= short_url_request.override_existing? ? "Yes" : "No" %></dd>
-
-  <dt>Route type:</dt>
-  <dd><%= short_url_request.route_type %></dd>
-
-  <dt>Segments mode:</dt>
-  <dd><%= short_url_request.segments_mode %></dd>
-
-  <dt>Reason:</dt>
-  <dd><%= short_url_request.reason %></dd>
-
-  <dt>Contact email:</dt>
-  <dd><%= short_url_request.contact_email %></dd>
-
-  <dt>State:</dt>
-  <dd><%= short_url_request.state.titleize %></dd>
-</dl>
+<%= render ShortUrlRequestDataComponent.new(
+  short_url_request: @short_url_request,
+) %>

--- a/app/views/short_url_requests/_similar_request_card.html.erb
+++ b/app/views/short_url_requests/_similar_request_card.html.erb
@@ -1,0 +1,37 @@
+<%= render "govuk_publishing_components/components/summary_card", {
+  title: similar_request.created_at.to_date.to_fs(:govuk_date),
+  rows: [
+    {
+      key: "Organisation",
+      value: similar_request.organisation_title,
+    },
+    {
+      key: "Target URL",
+      value: link_to(similar_request.to_path, govuk_url_for(similar_request.to_path))
+    },
+    {
+      key: "Override existing",
+      value: similar_request.override_existing? ? "Yes" : "No"
+    },
+    {
+      key: "Route type",
+      value: similar_request.route_type
+    },
+    {
+      key: "Segments mode",
+      value: similar_request.segments_mode
+    },
+    {
+      key: "Reason",
+      value: similar_request.reason
+    },
+    {
+      key: "Contact email",
+      value: similar_request.contact_email
+    },
+    {
+      key: "State",
+      value: similar_request.state.titleize
+    }
+  ]
+} %>

--- a/app/views/short_url_requests/show.html.erb
+++ b/app/views/short_url_requests/show.html.erb
@@ -1,6 +1,6 @@
 <% breadcrumb :short_url_request, @short_url_request %>
 
-<h1>URL redirect or Short URL requested by <%= @short_url_request.organisation_title %></h1>
+<h1 class="govuk-heading-xl">URL redirect or Short URL requested by <%= @short_url_request.organisation_title %></h1>
 
 <% if @short_url_request.state == 'pending' && @existing_redirect.present? %>
   <%= render 'existing_redirect', existing_redirect: @existing_redirect %>
@@ -8,22 +8,20 @@
 
 <%= render 'short_url_request_data', short_url_request: @short_url_request, show_short_url: true %>
 
-<div class="panel panel-default other-requests">
-  <div class="panel-heading">
-    <h2>Other requests for this short URL</h2>
-  </div>
-  <div class="panel-body">
-    <% if @short_url_request.similar_requests.any? %>
-      <ol>
-        <% @short_url_request.similar_requests.each do |similar_request| %>
-          <li><%= render 'short_url_request_data', short_url_request: similar_request, show_short_url: false %></li>
-        <% end %>
-      </ol>
-    <% else %>
-      <p>None</p>
+<% if @short_url_request.similar_requests.any? %>
+  <section class="govuk-!-margin-top-8 other-requests">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Other requests for this short URL:",
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4
+    } %>
+
+    <% @short_url_request.similar_requests.each do |similar_request| %>
+      <%= render "similar_request_card", similar_request: similar_request %>
     <% end %>
-  </div>
-</div>
+  </section>
+<% end %>
 
 <% unless allow_accepting_request? %>
   <div class="panel panel-danger">
@@ -38,9 +36,34 @@
   </div>
 <% end %>
 
-<% if @short_url_request.state == 'pending' %>
-  <%= button_to "Accept and create redirect", accept_short_url_request_path(@short_url_request), method: :post, class: "btn btn-success add-right-margin", disabled: allow_accepting_request? ? nil : 'disabled' %>
-  <%= link_to "Reject", new_rejection_short_url_request_path(@short_url_request), class: "btn btn-danger add-right-margin" %>
+<% if @short_url_request.state == "pending" %>
+  <%= form_with url: accept_short_url_request_path(@short_url_request), method: :post, local: true, class: "govuk-!-display-inline-block" do %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Accept and create redirect",
+      type: "submit",
+      inline_layout: true,
+      disabled: !allow_accepting_request?
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Reject",
+    href: new_rejection_short_url_request_path(@short_url_request),
+    secondary_solid: true,
+    inline_layout: true
+  } %>
 <% end %>
-<%= link_to "Edit", edit_short_url_request_path, class: "btn btn-default" %>
-<%= link_to "Delete", remove_short_url_request_path, class: "btn btn-danger" %>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: "Edit",
+  href: edit_short_url_request_path(@short_url_request),
+  secondary_solid: true,
+  inline_layout: true
+} %>
+
+<%= render "govuk_publishing_components/components/button", {
+  text: "Delete",
+  href: remove_short_url_request_path(@short_url_request),
+  destructive: true,
+  inline_layout: true
+} %>

--- a/spec/components/short_url_request_data_component_spec.rb
+++ b/spec/components/short_url_request_data_component_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe ShortUrlRequestDataComponent, type: :component do
+  include ViewComponent::TestHelpers
+
+  let(:short_url_request) { create(:short_url_request) }
+
+  it "renders the short URL request details" do
+    render_inline(described_class.new(short_url_request:))
+
+    expect(rendered_content).to include(short_url_request.organisation_title)
+    expect(rendered_content).to include(short_url_request.from_path)
+    expect(rendered_content).to include(short_url_request.to_path)
+    expect(rendered_content).to include(short_url_request.reason)
+    expect(rendered_content).to include(short_url_request.contact_email)
+    expect(rendered_content).to include("State")
+  end
+
+  it "renders the from path when show_short_url is true" do
+    render_inline(
+      described_class.new(
+        short_url_request:,
+        show_short_url: true,
+      ),
+    )
+
+    expect(rendered_content).to include("URL redirect or short URL")
+    expect(rendered_content).to include(short_url_request.from_path)
+  end
+
+  it "does not render the from path when show_short_url is false" do
+    render_inline(
+      described_class.new(
+        short_url_request:,
+        show_short_url: false,
+      ),
+    )
+
+    expect(rendered_content).not_to include("URL redirect or short URL")
+  end
+end

--- a/spec/features/short_url_manager_views_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_views_furl_requests_spec.rb
@@ -94,7 +94,7 @@ feature "Short URL manager finds information on short_url requests" do
     within ".other-requests" do
       # Don't have the main request in the other requests section
       expect(page).not_to have_content "Ministry of Beards"
-      expect(page).not_to have_content "12:00pm, 1 January 2014"
+      expect(page).not_to have_content "1 January 2014"
       expect(page).not_to have_content "/ministry-of-beards"
       expect(page).not_to have_link "/government/organisations/ministry-of-beards", href: "http://www.dev.gov.uk/government/organisations/ministry-of-beards"
       expect(page).not_to have_content "Beards are now their own department"
@@ -102,7 +102,7 @@ feature "Short URL manager finds information on short_url requests" do
 
       # Do have a relevant other request
       expect(page).to have_content "Ministry of Facial Hair"
-      expect(page).to have_content "12:00pm, 1 January 2013"
+      expect(page).to have_content "1 January 2013"
       expect(page).to have_content "/ministry-of-facial-hair"
       expect(page).to have_link "/government/organisations/ministry-of-facial-hair", href: "http://www.dev.gov.uk/government/organisations/ministry-of-facial-hair"
       expect(page).to have_content "Facial Hair department is all about beards"


### PR DESCRIPTION
## What

Migrate the pending request details screen off bootcamp and onto publishing components and the design system.  This includes:

- replacing the ‘<from_url> already redirects to…’ message with a warning text component https://components.publishing.service.gov.uk/component-guide/warning_text
- displaying the redirect data (and the data in ‘Other redirects’) in a summary list https://components.publishing.service.gov.uk/component-guide/summary_list
- conditionally displaying the “Other redirects” section so it is not shown if there aren’t any

Implement Sumi’s comments in the mural:

- consistency in field labels between this and other forms
- button types & text
- showing warning text at the top of the page
- see this mockup https://app.mural.co/t/govukdelivery7534/m/govukdelivery7534/1781098826749/525345de0dd5936f40f74eeb11ac76117f3120b8?wid=0-1781895190307 
- doesn’t include moving the buttons for now (we can do this at the end of the migration if we want to)
- make sure the whole page uses the design system page template styles, spacings, page title etc

## Why

So the user can review and action any pending redirects.

### AC

The view pending redirect show page is no longer renders any bootstrap components, using the design system instead.

### Screenshots
Before: 
<img width="2048" height="3340" alt="image (8)" src="https://github.com/user-attachments/assets/ac18fff9-5dab-44b6-b4eb-59e81b232347" />


After:
<img width="547" height="1024" alt="Screenshot 2026-08-12 at 14 38 34" src="https://github.com/user-attachments/assets/a699fd5c-89fb-45ba-80d5-11e20627730d" />
<img width="547" height="644" alt="Screenshot 2026-08-12 at 14 38 43" src="https://github.com/user-attachments/assets/0478bf60-8f17-4d45-bb4e-dc8a7e343c37" />

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3655)
