### PR TITLE
Migrate view pending confirmation and error screens [WHIT-3657]

### DIFF
--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -1,6 +1,6 @@
 class ShortUrlRequestsController < ApplicationController
-  layout "design_system", only: %i[new show index create]
-  layout "design_system", only: %i[new edit show index create update] if Rails.env.development?
+  layout "design_system", only: %i[new accept edit show new_rejection remove index create]
+  layout "design_system", only: %i[new accept edit show index create new_rejection destroy remove update] if Rails.env.development?
 
   before_action :authorise_as_short_url_requester!, only: %i[new create]
   before_action :authorise_as_short_url_manager!, only: %i[index show accept new_rejection reject list_short_urls edit update destroy remove]
@@ -76,7 +76,7 @@ class ShortUrlRequestsController < ApplicationController
   def destroy
     Commands::ShortUrlRequests::Destroy.new(get_short_url_request).call(
       success: lambda {
-        flash.notice = "Short URL #{get_short_url_request.from_path} was deleted."
+        flash[:success] = "Short URL request #{get_short_url_request.from_path} was deleted."
       },
       failure: lambda {
         flash.alert = "Failed to delete Short URL #{get_short_url_request.from_path}."

--- a/app/views/short_url_requests/accept.html.erb
+++ b/app/views/short_url_requests/accept.html.erb
@@ -1,13 +1,22 @@
 <% breadcrumb :short_url_request_accepted, @short_url_request %>
 
-<h1>The redirect has been published</h1>
+<h1 class="govuk-heading-xl">The redirect has been published</h1>
 
-<dl>
-  <dt>From:</dt>
-  <dd><%= link_to @short_url_request.redirect.from_path, govuk_url_for(@short_url_request.redirect.from_path) %></dd>
+<%= render "govuk_publishing_components/components/summary_list", {
+  items: [
+    {
+      field: "From:",
+      value: link_to(@short_url_request.redirect.from_path, govuk_url_for(@short_url_request.redirect.from_path))
+    },
+    {
+      field: "To:",
+      value: link_to(@short_url_request.redirect.to_path, govuk_url_for(@short_url_request.redirect.to_path))
+    }
+  ]
+} %>
 
-  <dt>To:</dt>
-  <dd><%= link_to @short_url_request.redirect.to_path, govuk_url_for(@short_url_request.redirect.to_path) %></dd>
-</dl>
+<%= render "govuk_publishing_components/components/button", {
+  text: "Submit",
+  href: short_url_request_path
+} %>
 
-<%= link_to "Done", short_url_requests_path, class: "btn btn-default" %>

--- a/app/views/short_url_requests/accept.html.erb
+++ b/app/views/short_url_requests/accept.html.erb
@@ -16,7 +16,7 @@
 } %>
 
 <%= render "govuk_publishing_components/components/button", {
-  text: "Submit",
+  text: "Done",
   href: short_url_request_path
 } %>
 

--- a/app/views/short_url_requests/accept_failed.html.erb
+++ b/app/views/short_url_requests/accept_failed.html.erb
@@ -1,5 +1,6 @@
 <% breadcrumb :short_url_request_accepted_failed, @short_url_request %>
 
-<h1>The redirect could not be published</h1>
-
-<%= render_errors_for @short_url_request.redirect, leading_message: "The URL redirect or short URL could not be created for the following reasons:" %>
+<%= render "govuk_publishing_components/components/error_alert", {
+  message: "The redirect could not be published",
+  description: @short_url_request.redirect.errors.full_messages.to_sentence
+} %>

--- a/app/views/short_url_requests/new_rejection.html.erb
+++ b/app/views/short_url_requests/new_rejection.html.erb
@@ -1,22 +1,25 @@
 <% breadcrumb :reject_short_url_request, @short_url_request %>
 
-<h1>Reject this URL redirect or short URL request</h1>
+<h1 class="govuk-heading-xl">Reject this URL redirect or short URL request</h1>
 
 <%= render 'short_url_request_data', short_url_request: @short_url_request, show_short_url: true %>
 
 <%= form_for @short_url_request, url: { action: :reject }, method: :post do |f| %>
   <%= render_errors_for @short_url_request, leading_message: "The short URL request could not be rejected for the following reasons:" %>
-  <fieldset>
-    <div class="form-group">
-      <%= f.label :rejection_reason, "Reason" %>
-      <%= f.text_area :rejection_reason, class: 'form-control' %>
-      <p class="help-block">Optionally, tell the requester why you are rejecting their request.</p>
-    </div>
-  </fieldset>
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Reason",
+        heading_size: "s"
+      },
+      name: f.field_name(:rejection_reason),
+      textarea_id: f.field_id(:rejection_reason),
+      value: @short_url_request.rejection_reason,
+      error_message: error_message_for(:rejection_reason, @short_url_request.errors),
+      hint: "Optionally, tell the requester why you are rejecting their request."
+    } %>
 
-  <fieldset>
-    <div class="form-group">
-      <%= f.submit "Reject", class: 'btn btn-danger' %>
-    </div>
-  </fieldset>
+<%= render "govuk_publishing_components/components/button", {
+  text: "Reject",
+  destructive: true
+} %>
 <%- end -%>

--- a/app/views/short_url_requests/remove.html.erb
+++ b/app/views/short_url_requests/remove.html.erb
@@ -1,13 +1,32 @@
 <% breadcrumb :remove_short_url_request, @short_url_request %>
 
-<h1>Delete URL redirect or Short URL <%= @short_url_request.from_path %></h1>
+<h1 class="govuk-heading-xl">Are you sure you want to delete this URL redirect or Short URL request?</h1>
+
+<%= render "govuk_publishing_components/components/summary_list", {
+  items: [
+    {
+      field: "From",
+      value: @short_url_request.from_path
+    },
+    {
+      field: "To",
+      value: @short_url_request.to_path
+    }
+  ]
+} %>
 
 <%= form_for(@short_url_request, html: { method: :delete }) do |f| %>
   <%= render_errors_for @short_url_request, leading_message: "Your submission failed for the following reasons:" %>
-  <fieldset>
-    <div class="form-group">
-      <%= f.submit "Delete", class: 'btn btn-danger' %>
-      <%= link_to "Cancel", short_url_request_path(@short_url_request), class: "btn btn-default add-left-margin" %>
-    </div>
-  </fieldset>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Delete",
+      type: "submit",
+      destructive: true,
+      inline_layout: true
+    } %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Cancel",
+      href: short_url_request_path(@short_url_request),
+      secondary_solid: true,
+      inline_layout: true
+    } %>
 <%- end -%>

--- a/spec/controllers/short_url_requests_controller_spec.rb
+++ b/spec/controllers/short_url_requests_controller_spec.rb
@@ -362,7 +362,8 @@ describe ShortUrlRequestsController do
         get :remove, params: { id: short_url_request.id }
         expect(response).to have_http_status(200)
         expect(response).to render_template(:remove)
-        expect(response.body).to include("Delete URL redirect or Short URL /original")
+        expect(response.body).to include("Are you sure you want to delete this URL redirect or Short URL request?")
+        expect(response.body).to include("/original")
       end
     end
   end


### PR DESCRIPTION
## What

Migrate the delete, reject and approve journeys for a pending request.  This includes:
- the delete confirmation screen:
   - change the title to ‘Delete redirect or short URL?’ and move the actual redirect information into a [summary list](https://components.publishing.service.gov.uk/component-guide/summary_list) (like the reject screen)
   - change the flash message to a [success alert](https://components.publishing.service.gov.uk/component-guide/success_alert)
- the reject confirmation screen:
  - replace the redirect data with a summary list
  - change the flash message to a success alert
- the approval screen
- the error screen:
  - do not display in an error summary
  - use an [error alert](https://components.publishing.service.gov.uk/component-guide/error_alert) to display the human readable part of the error message 
  - display the response body in a suitably formatted  element
 
## Why

So a user can action a pending short url or redirect request

### AC

The screens above no longer render any bootcamp components


### Screenshots


[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3657)