### PR TITLE
Create a view component to render the state of a short url request [WHIT-3741]

### DIFF
--- a/app/components/request_status_component.html.erb
+++ b/app/components/request_status_component.html.erb
@@ -1,0 +1,4 @@
+<%= render "govuk_publishing_components/components/tag", {
+  text: text,
+  colour: colour
+} %>

--- a/app/components/request_status_component.rb
+++ b/app/components/request_status_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class RequestStatusComponent < ViewComponent::Base
+  COLOURS = {
+    "accepted" => "green",
+    "pending" => "blue",
+    "rejected" => "red",
+    "superseded" => "grey",
+  }.freeze
+
+  def initialize(short_url_request)
+    super()
+    @short_url_request = short_url_request
+  end
+
+  def text
+    @short_url_request.state.titleize
+  end
+
+  def colour
+    COLOURS.fetch(@short_url_request.state, "grey")
+  end
+end

--- a/app/components/short_url_request_data_component.rb
+++ b/app/components/short_url_request_data_component.rb
@@ -44,7 +44,7 @@ class ShortUrlRequestDataComponent < ViewComponent::Base
       },
       {
         field: "State",
-        value: @short_url_request.state.titleize,
+        value: render(RequestStatusComponent.new(@short_url_request)),
       },
     ]
   end

--- a/app/views/short_url_requests/_form.html.erb
+++ b/app/views/short_url_requests/_form.html.erb
@@ -3,7 +3,7 @@
   items: [
     {
       field: "State:",
-      value: @short_url_request.state.titleize
+      value: render(RequestStatusComponent.new(@short_url_request))
     }
   ]
   } %>

--- a/app/views/short_url_requests/_similar_request_card.html.erb
+++ b/app/views/short_url_requests/_similar_request_card.html.erb
@@ -31,7 +31,7 @@
     },
     {
       key: "State",
-      value: similar_request.state.titleize
+      value: render(RequestStatusComponent.new(similar_request))
     }
   ]
 } %>

--- a/spec/components/request_status_component_spec.rb
+++ b/spec/components/request_status_component_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RequestStatusComponent, type: :component do
+  include ViewComponent::TestHelpers
+
+  it "renders a green tag for an accepted request" do
+    short_url_request = create(:short_url_request, :accepted)
+    component = described_class.new(short_url_request)
+
+    allow(component).to receive(:render).and_call_original
+    render_inline(component)
+
+    expect(component).to have_received(:render).with(
+      "govuk_publishing_components/components/tag",
+      hash_including(colour: "green"),
+    )
+    expect(page).to have_text("Accepted")
+  end
+
+  it "renders a blue tag for a pending request" do
+    short_url_request = create(:short_url_request, :pending)
+    component = described_class.new(short_url_request)
+
+    allow(component).to receive(:render).and_call_original
+    render_inline(component)
+
+    expect(component).to have_received(:render).with(
+      "govuk_publishing_components/components/tag",
+      hash_including(colour: "blue"),
+    )
+    expect(page).to have_text("Pending")
+  end
+
+  it "renders a red tag for a rejected request" do
+    short_url_request = create(:short_url_request, :rejected)
+    component = described_class.new(short_url_request)
+
+    allow(component).to receive(:render).and_call_original
+    render_inline(component)
+
+    expect(component).to have_received(:render).with(
+      "govuk_publishing_components/components/tag",
+      hash_including(colour: "red"),
+    )
+    expect(page).to have_text("Rejected")
+  end
+
+  it "renders a grey tag for a superseded request" do
+    short_url_request = create(:short_url_request, :superseded)
+    component = described_class.new(short_url_request)
+
+    allow(component).to receive(:render).and_call_original
+    render_inline(component)
+
+    expect(component).to have_received(:render).with(
+      "govuk_publishing_components/components/tag",
+      hash_including(colour: "grey"),
+    )
+    expect(page).to have_text("Superseded")
+  end
+end


### PR DESCRIPTION
## What

Create a new view component that displays the status of a ShortUrlRequest in the tag component 
There are four statuses:
- Accepted - green
- Pending - blue
- Rejected - red
- Superseded - grey

The tag should display the state in the colours above

Use the new component in the form partial that has already been migrated

## Why

- To make the state of the request clearer in forms and tables
- So the state can be displayed consistently across these location

### Screenshots

<img width="866" height="41" alt="Screenshot 2026-08-24 at 14 24 18" src="https://github.com/user-attachments/assets/fbc16e69-778a-47e0-b62f-2438bbff9fcc" />
<img width="859" height="41" alt="Screenshot 2026-08-24 at 14 24 51" src="https://github.com/user-attachments/assets/cf6a843e-ab19-48ed-a437-d54c65bdf702" />
<img width="859" height="39" alt="Screenshot 2026-08-24 at 14 25 28" src="https://github.com/user-attachments/assets/12a7518b-c6fe-4e58-acf2-065c9c27fd27" />
<img width="850" height="36" alt="Screenshot 2026-08-24 at 14 26 46" src="https://github.com/user-attachments/assets/a9de47dc-5d88-4650-85e9-f5d18632c7b7" />



[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3741)