### PR TITLE
Migrate live requests list [WHIT-3872]

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "modules/dl";
 @import "modules/form";
 @import "modules/other_requests";
+@import "modules/table";
 
 @import "layouts/application";
 

--- a/app/assets/stylesheets/modules/_table.scss
+++ b/app/assets/stylesheets/modules/_table.scss
@@ -1,0 +1,8 @@
+.govuk-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.govuk-table__cell {
+  overflow-wrap: break-word;
+}

--- a/app/controllers/short_url_requests_controller.rb
+++ b/app/controllers/short_url_requests_controller.rb
@@ -1,6 +1,6 @@
 class ShortUrlRequestsController < ApplicationController
-  layout "design_system", only: %i[new accept edit show new_rejection remove index create]
-  layout "design_system", only: %i[new accept edit show index create new_rejection destroy remove update] if Rails.env.development?
+  layout "design_system", only: %i[new accept edit show new_rejection list_short_urls remove index create]
+  layout "design_system", only: %i[new accept edit show index create new_rejection destroy remove update list_short_urls] if Rails.env.development?
 
   before_action :authorise_as_short_url_requester!, only: %i[new create]
   before_action :authorise_as_short_url_manager!, only: %i[index show accept new_rejection reject list_short_urls edit update destroy remove]

--- a/app/views/short_url_requests/list_short_urls.html.erb
+++ b/app/views/short_url_requests/list_short_urls.html.erb
@@ -1,30 +1,50 @@
 <% breadcrumb :live_short_urls %>
 
-<table class="table table-bordered table-hover" data-module="filterable-table">
-  <thead>
-    <tr class="table-header">
-      <th>Organisation</th>
-      <th>From</th>
-      <th>To</th>
-      <th>State</th>
-      <th>Date</th>
-    </tr>
-    <tr class="if-no-js-hide table-header-secondary">
-      <td colspan="5">
-        <form>
-          <label for="url-list-filter" class="rm">Filter short URLs</label>
-          <input id="url-list-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter short URLs">
-        </form>
-      </td>
-    </tr>
-  </thead>
-  <% @accepted_short_urls.each do |request| %>
-    <tr class="clickable-row">
-      <td><%= link_to request.organisation_title, short_url_request_path(request) %></td>
-      <td><%= link_to request.from_path, short_url_request_path(request) %></td>
-      <td><%= link_to request.to_path, short_url_request_path(request) %></td>
-      <td><%= link_to request.state.titleize, short_url_request_path(request) %></td>
-      <td><%= link_to request.updated_at.to_date, short_url_request_path(request) %></td>
-    </tr>
-  <% end %>
-</table>
+<h1 class="govuk-heading-xl">Live URL redirects and short URLs</h1>
+
+<%= render "govuk_publishing_components/components/table", {
+  filterable: true,
+  label: "Filter short URLs",
+  head: [
+    {
+      text: "Organisation"
+    },
+    {
+      text: "From"
+    },
+    {
+      text: "To"
+    },
+    {
+      text: "State"
+    },
+    {
+      text: "Date"
+    },
+    {
+      text: "Action"
+    }
+  ],
+  rows: @accepted_short_urls.map { |r|
+    [
+      {
+        text: r.organisation_title
+      },
+      {
+        text: r.from_path
+      },
+      {
+        text: r.to_path
+      },
+      {
+        text: render(RequestStatusComponent.new(r))
+      },
+      {
+        text: r.updated_at.to_date
+      },
+      {
+        text: link_to("View", short_url_request_path(r))
+      }
+    ]
+  }
+} %>

--- a/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
+++ b/spec/features/short_url_manager_responds_to_furl_requests_spec.rb
@@ -98,7 +98,9 @@ feature "Short URL manager responds to short URL requests" do
   scenario "Short URL manager edits a short URL" do
     visit list_short_urls_path
 
-    click_on "Ministry of Hair"
+    within("tr", text: "Ministry of Hair") do
+      click_on "View"
+    end
     click_on "Edit"
 
     target_url = "/government/organisations/ministry-of-long-hair"


### PR DESCRIPTION
What
Migrate the ‘view live requests’ listing screen onto publishing components gem components.  

This includes:
- using the [table component with filtering option](https://components.publishing.service.gov.uk/component-guide/table#with_filter) to replace the current filtering
- following the pattern used in the ‘view pending’ listing screen to replace clickable rows with an action column and ‘View’ link
- fixing the page title, spacing etc 
- switching to the design system layout in production
- making sure any flash messages etc remain on the listing screen

This does not include:
- adding pagination to the table

### Screenshots:

Before:
<img width="2048" height="3478" alt="b9163374-b79c-4456-8fbc-c0bdd711ce25" src="https://github.com/user-attachments/assets/32d03cf1-b236-4c03-a606-0e60492259f6" />

After:
<img width="855" height="1207" alt="Screenshot 2026-09-07 at 11 33 10" src="https://github.com/user-attachments/assets/9187873e-42d7-4274-b7e7-04d7040cc0d2" />


[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3872)