### PR TITLE
Fix typo in navbar

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -27,7 +27,7 @@
       href: "/"
     },
     {
-      text: "Swtich app",
+      text: "Switch app",
       href: Plek.external_url_for("signon")
     }
   ]


### PR DESCRIPTION
Small typo in the navbar needed to be fixed. 
